### PR TITLE
feat: camera extension

### DIFF
--- a/extensions/camera/README.md
+++ b/extensions/camera/README.md
@@ -1,0 +1,16 @@
+# Camera Extension Specification
+
+**This is a work in progress and has not been reviewed everything is likely to change**
+
+- **Title**: Camera
+- **Identifier**: https://linz.github.io/STAC/extensions/camera/v1.0.0/schema.json
+- **Field Name Prefix**: camera
+- **Scope**: Item, Collection
+- **Extension Classification**: Work In Progress (Before proposal)
+
+## Item Properties or Asset Fields
+
+| Field Name       | Type                     | Description |
+| ---------------- | ------------------------ | ----------- |
+| camera:sequence_number | integer | Also referred to as veder; the sequential order of photos taken by an individual camera |
+| camera:nominal_focal_length | integer | Distance in mm from the camera lens centre to the film in the camera at which the image will have the least possible distortion. |

--- a/extensions/camera/README.md
+++ b/extensions/camera/README.md
@@ -5,7 +5,7 @@
 - **Title**: Camera
 - **Identifier**: https://linz.github.io/STAC/extensions/camera/v1.0.0/schema.json
 - **Field Name Prefix**: camera
-- **Scope**: Item, Collection
+- **Scope**: Item
 - **Extension Classification**: Work In Progress (Before proposal)
 
 ## Item Properties or Asset Fields

--- a/extensions/camera/examples/item.json
+++ b/extensions/camera/examples/item.json
@@ -1,0 +1,31 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "TODO: URL"
+    ],
+    "type": "Feature",
+    "id": "72360",
+    "geometry": null,
+    "properties": {
+        "datetime": "1952-04-23T00:00:00.000",
+        "platform": "Fixed-wing Aircraft",
+        "instruments": [
+            "EAGLE IV"
+        ],
+        "mission": "SURVEY_1",
+        "camera:sequence_number": 89554,
+        "camera:nominal_focal_length": 508
+    },
+    "links": [],
+    "assets": {
+        ".his": {
+            "href": "./72360.his",
+            "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        "image/tiff; application=geotiff; profile=cloud-optimized": {
+            "href": "./72360.tiff",
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+        }
+    }
+}

--- a/extensions/camera/examples/item.json
+++ b/extensions/camera/examples/item.json
@@ -1,7 +1,7 @@
 {
     "stac_version": "1.0.0",
     "stac_extensions": [
-        "TODO: URL"
+        "https://linz.github.io/STAC/extensions/camera/v1.0.0/schema.json"
     ],
     "type": "Feature",
     "id": "72360",

--- a/extensions/camera/json-schema/schema.json
+++ b/extensions/camera/json-schema/schema.json
@@ -37,37 +37,6 @@
                     "$ref": "#/definitions/stac_extensions"
                 }
             ]
-        },
-        {
-            "$comment": "This is the schema for STAC Collections.",
-            "allOf": [
-                {
-                    "type": "object",
-                    "required": [
-                        "type"
-                    ],
-                    "properties": {
-                        "type": {
-                            "const": "Collection"
-                        },
-                        "assets": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "$ref": "#/definitions/fields"
-                            }
-                        },
-                        "item_assets": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "$ref": "#/definitions/fields"
-                            }
-                        }
-                    }
-                },
-                {
-                    "$ref": "#/definitions/stac_extensions"
-                }
-            ]
         }
     ],
     "definitions": {
@@ -99,12 +68,12 @@
                     "type": [
                         "integer"
                     ]
-                },
-                "patternProperties": {
-                    "^(?!camera:)": {}
-                },
-                "additionalProperties": false
-            }
+                }
+            },
+            "patternProperties": {
+                "^(?!camera:)": {}
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/extensions/camera/json-schema/schema.json
+++ b/extensions/camera/json-schema/schema.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://linz.github.io/STAC/extensions/camera/v1.0.0/schema.json",
+    "title": "Camera Extension",
+    "description": "STAC Camera Extension for STAC Items.",
+    "oneOf": [
+        {
+            "$comment": "This is the schema for STAC Items.",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "type",
+                        "properties",
+                        "assets"
+                    ],
+                    "properties": {
+                        "type": {
+                            "const": "Feature"
+                        },
+                        "properties": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/fields"
+                                }
+                            ]
+                        },
+                        "assets": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/fields"
+                            }
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/stac_extensions"
+                }
+            ]
+        },
+        {
+            "$comment": "This is the schema for STAC Collections.",
+            "allOf": [
+                {
+                    "type": "object",
+                    "required": [
+                        "type"
+                    ],
+                    "properties": {
+                        "type": {
+                            "const": "Collection"
+                        },
+                        "assets": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/fields"
+                            }
+                        },
+                        "item_assets": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/fields"
+                            }
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/stac_extensions"
+                }
+            ]
+        }
+    ],
+    "definitions": {
+        "stac_extensions": {
+            "type": "object",
+            "required": [
+                "stac_extensions"
+            ],
+            "properties": {
+                "stac_extensions": {
+                    "type": "array",
+                    "contains": {
+                        "const": "https://linz.github.io/STAC/extensions/camera/v1.0.0/schema.json"
+                    }
+                }
+            }
+        },
+        "fields": {
+            "type": "object",
+            "properties": {
+                "camera:sequence_number": {
+                    "title": "Sequence Number",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "camera:nominal_focal_length": {
+                    "title": "Nominal Focal Length",
+                    "type": [
+                        "integer"
+                    ]
+                },
+                "patternProperties": {
+                    "^(?!camera:)": {}
+                },
+                "additionalProperties": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
STAC json schema for the **camera extension** specificied in STAC/extension/historical_imagery/README.md

Created using the projection extension code as a guide: https://github.com/stac-extensions/projection
nb: the `$id` and `const` links currently do not work