### PR TITLE
chore: use license plain text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,397 +1,395 @@
-<!DOCTYPE html>
-<html>
-<head>
-<title>Creative Commons — Attribution 4.0 International — CC BY 4.0</title>
-<meta charset="UTF-8">
-<script type="text/javascript" src="//creativecommons.org/includes/errata.js"></script>
+Attribution 4.0 International
 
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700" rel="stylesheet">
-<link rel='stylesheet' id='cc-fontello-css' href="https://creativecommons.org/wp-content/themes/cc/fonts/fontello/css/cc-fontello.css" type='text/css' media='all' />
-<link rel='stylesheet' id='parent-style-css' href="https://creativecommons.org/wp-content/themes/twentysixteen/style.css" type='text/css' media='all' />
-<link rel='stylesheet' id='cc-style-css' href="https://creativecommons.org/wp-content/themes/cc/css/app.css" type='text/css' media='all' />
-<link rel="stylesheet" type="text/css" href="/includes/legalcode.css" media="screen" />
-<link rel="stylesheet" type="text/css" href="/includes/legalcode-print.css" media="print" />
-<script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+=======================================================================
 
-</head>
-<body class="lang-en">
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
 
-<div class="site-header-wrapper">
-<header id="masthead" class="site-header sticky-nav-main sticky attached" role="banner">
-<div class="site-header-main">
-<div class="site-branding">
-<a class="cc-site-logo-link" href="https://creativecommons.org/" rel="home">
-<img class="cc-site-logo" src="https://creativecommons.org/wp-content/themes/cc/images/cc.logo.white.svg" height="72" width="303">
-</a>
-</div>
-<button id="menu-toggle" class="menu-toggle"><i class="cc-icon-menu"></i> <span>Menu</span></button>
-<div id="site-header-menu" class="site-header-menu">
-<nav id="mobile-navigation" class="mobile-navigation" role="navigation" aria-label="Mobile Menu">
-<div class="menu-mobile-menu-container"><ul id="menu-mobile-menu" class="mobile-menu">
-<li id="menu-item-48798" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48798"><a href="https://creativecommons.org/share-your-work/">Share your work</a></li>
-<li id="menu-item-48799" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48799"><a href="https://creativecommons.org/use-remix/">Use &amp; remix</a></li>
-<li id="menu-item-48800" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48800"><a href="https://creativecommons.org/about/">What we do</a></li>
-<li id="menu-item-48801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48801"><a href="https://creativecommons.org/blog/">Blog</a></li>
-<li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://creativecommons.org/about/global-affiliate-network/">Global Affiliate Network</a></li>
-<li id="menu-item-48803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48803"><a href="https://creativecommons.org/use-remix/search-the-commons/">Search the Commons</a></li>
-</ul></div>
-</nav>
-<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="Primary Menu">
-<div class="menu-primary-menu-container"><ul id="menu-primary-menu" class="primary-menu">
-<li id="menu-item-48791" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48791"><a href="https://creativecommons.org/share-your-work/">Share your work</a></li>
-<li id="menu-item-48792" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48792"><a href="https://creativecommons.org/use-remix/">Use &amp; remix</a></li>
-<li id="menu-item-48570" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48570"><a href="https://creativecommons.org/about/">What we do</a></li>
-<li id="menu-item-48793" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48793"><a href="https://creativecommons.org/blog/">Blog</a></li>
-</ul></div>
-</nav>
-<nav id="secondary-navigation" class="secondary-navigation" role="navigation" aria-label="Secondary Menu">
-<div class="menu-secondary-menu-container"><ul id="menu-secondary-menu" class="secondary-menu"><li id="menu-item-48804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48804"><a href="https://creativecommons.org/about/global-affiliate-network/">Global Affiliate Network</a></li>
-<li id="menu-item-48805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48805"><a href="https://creativecommons.org/use-remix/search-the-commons/">Search the Commons</a></li>
-<li id="menu-item-48806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48806"><a href="https://creativecommons.org/about/contact/">Contact</a></li>
-</ul></div>
-</nav>
-<nav id="social-navigation" class="social-navigation" role="navigation" aria-label="Social Links Menu">
-<div class="menu-social-links-container"><ul id="menu-social-links" class="social-links-menu">
-<li id="menu-item-48807" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48807"><a href="https://www.facebook.com/creativecommons"><span class="screen-reader-text">Facebook</span></a></li>
-<li id="menu-item-48808" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48808"><a href="https://twitter.com/creativecommons"><span class="screen-reader-text">Twitter</span></a></li>
-<li id="menu-item-48809" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48809"><a href="mailto:info@creativecommons.org"><span class="screen-reader-text">Mail</span></a></li>
-</ul></div>
-</nav>
-</div>
-</div>
-</header>
-<header class="site-header spacer" role="banner">
-<div class="site-header-main">
-<div class="site-branding">
-<a class="cc-site-logo-link" href="https://creativecommons.org/" rel="home">
-<img class="cc-site-logo" src="https://creativecommons.org/wp-content/themes/cc/images/cc.logo.white.svg" height="72" width="303">
-</a>
-</div>
-<button id="menu-toggle" class="menu-toggle"><i class="cc-icon-menu"></i> <span>Menu</span></button>
-<div id="site-header-menu" class="site-header-menu">
-<nav id="mobile-navigation" class="mobile-navigation" role="navigation" aria-label="Mobile Menu">
-<div class="menu-mobile-menu-container"><ul id="menu-mobile-menu" class="mobile-menu">
-<li id="menu-item-48798" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48798"><a href="https://creativecommons.org/share-your-work/">Share your work</a></li>
-<li id="menu-item-48799" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48799"><a href="https://creativecommons.org/use-remix/">Use &amp; remix</a></li>
-<li id="menu-item-48800" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48800"><a href="https://creativecommons.org/about/">What we do</a></li>
-<li id="menu-item-48801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48801"><a href="https://creativecommons.org/blog/">Blog</a></li>
-<li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://creativecommons.org/about/global-affiliate-network/">Global Affiliate Network</a></li>
-<li id="menu-item-48803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48803"><a href="https://creativecommons.org/use-remix/search-the-commons/">Search the Commons</a></li>
- </ul></div>
-</nav>
-<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="Primary Menu">
-<div class="menu-primary-menu-container"><ul id="menu-primary-menu" class="primary-menu">
-<li id="menu-item-48791" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48791"><a href="https://creativecommons.org/share-your-work/">Share your work</a></li>
-<li id="menu-item-48792" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48792"><a href="https://creativecommons.org/use-remix/">Use &amp; remix</a></li>
-<li id="menu-item-48570" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48570"><a href="https://creativecommons.org/about/">What we do</a></li>
-<li id="menu-item-48793" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48793"><a href="https://creativecommons.org/blog/">Blog</a></li>
-</ul></div>
-</nav>
-<nav id="secondary-navigation" class="secondary-navigation" role="navigation" aria-label="Secondary Menu">
-<div class="menu-secondary-menu-container"><ul id="menu-secondary-menu" class="secondary-menu"><li id="menu-item-48804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48804"><a href="https://creativecommons.org/about/global-affiliate-network/">Global Affiliate Network</a></li>
-<li id="menu-item-48805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48805"><a href="https://creativecommons.org/use-remix/search-the-commons/">Search the Commons</a></li>
-<li id="menu-item-48806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48806"><a href="https://creativecommons.org/about/contact/">Contact</a></li>
-</ul></div>
-</nav>
-<nav id="social-navigation" class="social-navigation" role="navigation" aria-label="Social Links Menu">
-<div class="menu-social-links-container"><ul id="menu-social-links" class="social-links-menu">
-<li id="menu-item-48807" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48807"><a href="https://www.facebook.com/creativecommons"><span class="screen-reader-text">Facebook</span></a></li>
-<li id="menu-item-48808" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48808"><a href="https://twitter.com/creativecommons"><span class="screen-reader-text">Twitter</span></a></li>
-<li id="menu-item-48809" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-48809"><a href="mailto:info@creativecommons.org"><span class="screen-reader-text">Mail</span></a></li>
-</ul></div>
-</nav>
-</div>
-</div>
-</header>
-</div>
-<aside id="header-below" class="widget-area">
-<section id="text-15" class="widget-1 widget-first widget-last widget-odd widget widget_text">
-<div class="textwidget">
-<div id="donation-bar-wrapper" class="donation-bar-wrapper">
-<div id="donation-bar-inner" class="donation-bar-inner">
-<p class="donate-text">Help us build a vibrant, collaborative global commons</p>
-<div class="donate-action"><a href="/donate?utm_campaign=2018fund&utm_source=license_header2018" class="button donate arrow">Donate<span class="hide-on-mobile"> Now</span></a></div>
-</div>
-</div>
-</div>
-</section>
-</aside>
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+     wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+     wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
 
 
-<div id="language-selector-block" class="container">
-<div class="language-selector-inner">
-This page is available in the following languages:
-<img class="language-icon" src="/images/language_icon_x2.png" alt="Languages">
-<select>
-<option value="legalcode.ar">العربية</option>
-<option value="legalcode.cs">čeština</option>
-<option value="legalcode.de">Deutsch</option>
-<option value="legalcode.el">Ελληνικά</option>
-<option value="legalcode" selected="selected">English</option>
-<option value="legalcode.es">Español</option>
-<option value="legalcode.eu">euskara</option>
-<option value="legalcode.fi">suomeksi</option>
-<option value="legalcode.fr">français</option>
-<option value="legalcode.hr">hrvatski</option>
-<option value="legalcode.id">Bahasa Indonesia</option>
-<option value="legalcode.it">italiano</option>
-<option value="legalcode.ja">日本語</option>
-<option value="legalcode.ko">한국어</option>
-<option value="legalcode.lt">Lietuvių</option>
-<option value="legalcode.lv">latviski</option>
-<option value="legalcode.mi">te reo Māori</option>
-<option value="legalcode.nl">Nederlands</option>
-<option value="legalcode.no">norsk</option>
-<option value="legalcode.pl">polski</option>
-<option value="legalcode.pt">português</option>
-<option value="legalcode.ro">română</option>
-<option value="legalcode.ru">русский</option>
-<option value="legalcode.sl">Slovenščina</option>
-<option value="legalcode.sv">svenska</option>
-<option value="legalcode.tr">Türkçe</option>
-<option value="legalcode.uk">українська</option>
-<option value="legalcode.zh-Hans">中文</option>
-<option value="legalcode.zh-Hant">華語</option>
-</select>
-</div>
-</div>
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
 
 
-<div id="deed" class="green">
-<div id="deed-head">
-<div id="cc-logo"><span class="cc-icon-logo"><img src="/images/deed/svg/cc_white.svg" alt="CC" /></span><span class="cc-icon-by"><img src="/images/deed/svg/attribution_icon_white.svg" alt="Attribution" /></span></div>
-<h1><span>Creative Commons Legal Code</span></h1>
-<div id="deed-license">
-<h2>Attribution 4.0 International</h2>
-</div>
-</div>
-<div id="deed-main">
-<div id="deed-main-content">
-<div id="deed-disclaimer">
-<div class="summary">
-Official translations of this license are available <a href="#languages">in other languages</a>.
-</div>
-</div>
-<div class="shaded">
-<p>Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.</p>
-</div>
-<div class="shaded">
-<p><strong>Using Creative Commons Public Licenses</strong></p>
-<p>Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.</p>
-<p class="usage-considerations"><strong>Considerations for licensors:</strong> Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. <a href="//wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensors">More considerations for licensors.</a></p>
-<p class="usage-considerations"><strong>Considerations for the public:</strong> By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable.
-<a href="//wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees">More considerations for the public.</a></p>
-</div>
-<h3>Creative Commons Attribution 4.0 International Public License</h3>
-<p>By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.</p>
-<p id="s1"><strong>Section 1 – Definitions.</strong></p>
-<ol type="a">
-<li id="s1a"><strong>Adapted Material</strong> means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.</li>
-<li id="s1b"><strong>Adapter's License</strong> means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.</li>
-<li id="s1c"><strong>Copyright and Similar Rights</strong> means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section <a href="#s2b">2(b)(1)-(2)</a> are not Copyright and Similar Rights.</li>
-<li id="s1d"><strong>Effective Technological Measures</strong> means those measures that, in the absence of proper authority, may not
-be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar
-international agreements.</li>
-<li id="s1e"><strong>Exceptions and Limitations</strong> means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.</li>
-<li id="s1f"><strong>Licensed Material</strong> means the artistic or literary work, database, or other material to which the Licensor applied this Public License.</li>
-<li id="s1g"><strong>Licensed Rights</strong> means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.</li>
-<li id="s1h"><strong>Licensor</strong> means the individual(s) or entity(ies) granting rights under this Public License.</li>
-<li id="s1i"><strong>Share</strong> means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.</li>
-<li id="s1j"><strong>Sui Generis Database Rights</strong> means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.</li>
-<li id="s1k"><strong>You</strong> means the individual or entity exercising the Licensed Rights under this Public License. <strong>Your</strong> has a corresponding meaning.</li>
-</ol>
-<p id="s2"><strong>Section 2 – Scope.</strong></p>
-<ol type="a">
-<li id="s2a"><strong>License grant</strong>.
-<ol>
-<li id="s2a1">Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
-<ol type="A">
-<li id="s2a1A">reproduce and Share the Licensed Material, in whole or in part; and</li>
-<li id="s2a1B">produce, reproduce, and Share Adapted Material.</li>
-</ol>
-<li id="s2a2"><span style="text-decoration: underline;">Exceptions and Limitations</span>. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.</li>
-<li id="s2a3"><span style="text-decoration: underline;">Term</span>. The term of this Public License is specified in Section <a href="#s6a">6(a)</a>.</li>
-<li id="s2a4"><span style="text-decoration: underline;">Media and formats; technical modifications allowed</span>. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section <a href="#s2a4">2(a)(4)</a> never produces Adapted Material.</li>
-<li id="s2a5"><span style="text-decoration: underline;">Downstream recipients</span>.
-<div class="para">
-<ol type="A">
-<li id="s2a5A"><span style="text-decoration: underline;">Offer from the Licensor – Licensed Material</span>. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.</li>
-<li id="s2a5B"><span style="text-decoration: underline;">No downstream restrictions</span>. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.</li>
-</ol>
-</div>
-<li id="s2a6"><span style="text-decoration: underline;">No endorsement</span>. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section <a href="#s3a1Ai">3(a)(1)(A)(i)</a>.</li>
-</ol>
-<li id="s2b"><p><strong>Other rights</strong>.</p>
-<ol>
-<li id="s2b1">Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.</li>
-<li id="s2b2">Patent and trademark rights are not licensed under this Public License.</li>
-<li id="s2b3">To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.</li>
-</ol>
-</li>
-</ol>
-<p id="s3"><strong>Section 3 – License Conditions.</strong></p>
-<p>Your exercise of the Licensed Rights is expressly made subject to the following conditions.</p>
-<ol type="a">
-<li id="s3a"><p><strong>Attribution</strong>.</p>
-<ol>
-<li id="s3a1"><p>If You Share the Licensed Material (including in modified form), You must:</p>
-<ol type="A">
-<li id="s3a1A">retain the following if it is supplied by the Licensor with the Licensed Material:
-<ol type="i">
-<li id="s3a1Ai">identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);</li>
-<li id="s3a1Aii">a copyright notice;</li>
-<li id="s3a1Aiii">a notice that refers to this Public License; </li>
-<li id="s3a1Aiv">a notice that refers to the disclaimer of warranties;</li>
-<li id="s3a1Av">a URI or hyperlink to the Licensed Material to the extent reasonably practicable;</li>
-</ol>
-<li id="s3a1B">indicate if You modified the Licensed Material and retain an indication of any previous modifications; and</li>
-<li id="s3a1C">indicate the Licensed Material is licensed under this Public License,
-and include the text of, or the URI or hyperlink to, this Public
-License.</li>
-</ol>
-</li>
-<li id="s3a2">You may satisfy the conditions in Section <a href="#s3a1">3(a)(1)</a> in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.</li>
-<li id="s3a3">If requested by the Licensor, You must remove any of the information required by Section <a href="#s3a1A">3(a)(1)(A)</a> to the extent reasonably practicable.</li>
- <li id="s3a4">If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.</li>
-</ol>
-</li>
-</ol>
-<p id="s4"><strong>Section 4 – Sui Generis Database Rights.</strong></p>
-<p>Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:</p>
-<ol type="a">
-<li id="s4a">for the avoidance of doubt, Section <a href="#s2a1">2(a)(1)</a> grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;</li>
-<li id="s4b">if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and</li>
-<li id="s4c">You must comply with the conditions in Section <a href="#s3a">3(a)</a> if You Share all or a substantial portion of the contents of the database.</li>
-</ol>
-For the avoidance of doubt, this Section <a href="#s4">4</a> supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
-<p id="s5"><strong>Section 5 – Disclaimer of Warranties and Limitation of Liability.</strong></p>
-<ol style="font-weight: bold;" type="a">
-<li id="s5a"><strong>Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.</strong></li>
-<li id="s5b"><strong>To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.</strong></li>
-</ol>
-<ol start="3" type="a">
-<li id="s5c">The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.</li>
-</ol>
-<p id="s6"><strong>Section 6 – Term and Termination.</strong></p>
-<ol type="a">
-<li id="s6a">This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.</li>
-<li id="s6b">
-<p>Where Your right to use the Licensed Material has terminated under Section <a href="#s6a">6(a)</a>, it reinstates:</p>
-<ol>
-<li id="s6b1">automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or</li>
-<li id="s6b2">upon express reinstatement by the Licensor.</li>
-</ol>
-For the avoidance of doubt, this Section <a href="#s6b">6(b)</a> does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.</li>
-<li id="s6c">For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.</li>
-<li id="s6d">Sections <a href="#s1">1</a>, <a href="#s5">5</a>, <a href="#s6">6</a>, <a href="#s7">7</a>, and <a href="#s8">8</a> survive termination of this Public License.</li>
-</ol>
-<p id="s7"><strong>Section 7 – Other Terms and Conditions.</strong></p>
-<ol type="a">
-<li id="s7a">The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.</li>
-<li id="s7b">Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.</li>
-</ol>
-<p id="s8"><strong>Section 8 – Interpretation.</strong></p>
-<ol type="a">
-<li id="s8a">For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.</li>
-<li id="s8b">To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.</li>
-<li id="s8c">No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.</li>
-<li id="s8d">Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.</li>
-</ol>
+Section 2 -- Scope.
 
-<p class="shaded">Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” The text of the Creative Commons public licenses is dedicated to the public domain under the <a href="//creativecommons.org/publicdomain/zero/1.0/legalcode">CC0 Public Domain Dedication</a>. Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at <a href="//creativecommons.org/policies">creativecommons.org/policies</a>, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.<br><br>
-Creative Commons may be contacted at <a href="//creativecommons.org/">creativecommons.org</a>.</p>
-<p class="shaded"><a id="languages"></a>Additional languages available:
+  a. License grant.
 
-<a href="/licenses/by/4.0/legalcode.ar">العربية</a>,
-<a href="/licenses/by/4.0/legalcode.cs">čeština</a>,
-<a href="/licenses/by/4.0/legalcode.de">Deutsch</a>,
-<a href="/licenses/by/4.0/legalcode.el">Ελληνικά</a>,
-<a href="/licenses/by/4.0/legalcode.es">Español</a>,
-<a href="/licenses/by/4.0/legalcode.eu">euskara</a>,
-<a href="/licenses/by/4.0/legalcode.fi">suomeksi</a>,
-<a href="/licenses/by/4.0/legalcode.fr">français</a>,
-<a href="/licenses/by/4.0/legalcode.hr">hrvatski</a>,
-<a href="/licenses/by/4.0/legalcode.id">Bahasa Indonesia</a>,
-<a href="/licenses/by/4.0/legalcode.it">italiano</a>,
-<a href="/licenses/by/4.0/legalcode.ja">日本語</a>,
-<a href="/licenses/by/4.0/legalcode.ko">한국어</a>,
-<a href="/licenses/by/4.0/legalcode.lt">Lietuvių</a>,
-<a href="/licenses/by/4.0/legalcode.lv">latviski</a>,
-<a href="/licenses/by/4.0/legalcode.mi">te reo Māori</a>,
-<a href="/licenses/by/4.0/legalcode.nl">Nederlands</a>,
-<a href="/licenses/by/4.0/legalcode.no">norsk</a>,
-<a href="/licenses/by/4.0/legalcode.pl">polski</a>,
-<a href="/licenses/by/4.0/legalcode.pt">português</a>,
-<a href="/licenses/by/4.0/legalcode.ro">română</a>,
-<a href="/licenses/by/4.0/legalcode.ru">русский</a>,
-<a href="/licenses/by/4.0/legalcode.sl">Slovenščina</a>,
-<a href="/licenses/by/4.0/legalcode.sv">svenska</a>,
-<a href="/licenses/by/4.0/legalcode.tr">Türkçe</a>,
-<a href="/licenses/by/4.0/legalcode.uk">українська</a>,
-<a href="/licenses/by/4.0/legalcode.zh-Hans">中文</a>,
-<a href="/licenses/by/4.0/legalcode.zh-Hant">華語</a>.
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
 
-Please read the <a href="/faq/#officialtranslations">FAQ</a> for more information about official translations. </p>
-</div>
-</div>
-<div id="deed-foot">
-<p id="footer"><a href="./">« Back to Commons Deed</a></p>
-</div>
-</div>
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
 
-<div class="site-footer-wrapper">
-<footer id="colophon" class="site-footer sticky-nav-main" role="contentinfo">
-<div class="cc-footer">
-<div class="column cc-footer-main">
-<div class="cc-footer-logo">
-<a href="https://creativecommons.org/" class="custom-logo-link" rel="home" itemprop="url"><img src="https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_.png" class="custom-logo" alt="cc.logo.white" itemprop="logo" srcset="https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_.png 980w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-300x73.png 300w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-768x188.png 768w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-140x34.png 140w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-50x12.png 50w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-270x66.png 270w, https://creativecommons.org/wp-content/uploads/2016/06/cc.logo_.white_-245x60.png 245w" sizes="(max-width: 709px) 85vw, (max-width: 909px) 67vw, (max-width: 1362px) 62vw, 840px" height="240" width="980"></a>
-</div>
-<div class="cc-footer-links">
-<div class="menu-footer-links-container">
-<ul id="menu-footer-links" class="menu">
-<li id="menu-item-48794" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48794"><a href="https://creativecommons.org/about/contact/">Contact</a></li>
-<li id="menu-item-48795" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48795"><a href="https://creativecommons.org/privacy/">Privacy</a></li>
-<li id="menu-item-48796" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48796"><a href="https://creativecommons.org/policies/">Policies</a></li>
-<li id="menu-item-48797" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48797"><a href="https://creativecommons.org/terms/">Terms</a></li>
-</ul>
-</div>
-</div>
-</div>
-<div class="column cc-footer-contact">
-<h6><a href="https://creativecommons.org/about/contact">We'd love to hear from you!</a></h6>
-<address>
-Creative Commons<br>
-PO Box 1866, Mountain View, CA 94042
-</address>
-<ul>
-<li><a href="mailto:info@creativecommons.org" class="mail">info@creativecommons.org</a></li>
-<li><a href="https://creativecommons.org/faq">Frequently Asked Questions</a></li>
-</ul>
-</div>
-<div class="column cc-footer-license">
-<div class="license-icons">
-<a rel="license" href="https://creativecommons.org/licenses/by/4.0/" title="Creative Commons Attribution 4.0 International license">
-<i class="cc-icon-cc"></i>
-<i class="cc-icon-cc-by"></i>
-</a>
-</div>
-<aside>
-<div xmlns:cc="https://creativecommons.org/ns#" about="https://creativecommons.org">
-<p>Except where otherwise <a class="subfoot" href="https://creativecommons.org/policies#license">noted</a>, content on this site is licensed under a <a class="subfoot" href="https://creativecommons.org/licenses/by/4.0/" rel="license">Creative Commons Attribution 4.0 International license</a>. <a class="subfoot" href="https://creativecommons.org/website-icons" target="blank">Icons</a> by The Noun Project.</p>
-</div>
-</aside>
-</div>
-</div>
-</footer>
-</div>
-<script type='text/javascript'>
-  /* <![CDATA[ */
-  var screenReaderText = {"expand":"expand child menu","collapse":"collapse child menu"};
-  /* ]]> */
-</script>
-<script type='text/javascript' src='https://creativecommons.org/wp-content/themes/twentysixteen/js/functions.js'></script>
-<script type='text/javascript' src='/includes/legalcode.js'></script>
+            b. produce, reproduce, and Share Adapted Material.
 
-</body>
-</html>
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
+
+Creative Commons may be contacted at creativecommons.org.


### PR DESCRIPTION
Sourced from https://creativecommons.org/licenses/by/4.0/legalcode.txt. GitHub should then recognise license via https://choosealicense.com/licenses/cc-by-4.0/#.