### PR TITLE
fix: Use portable shebang line

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 node_modules/.bin/stac-node-validator \
     --schemaMap=https://linz.github.io/stac/__STAC_VERSION__/template/schema.json=extensions/template/schema.json \
     --schemaMap=https://linz.github.io/stac/__STAC_VERSION__/camera/schema.json=extensions/camera/schema.json \


### PR DESCRIPTION
Makes it possible to run this script on NixOS and other distributions
with a different path to the Bash shell.