### PR TITLE
refactor: Simplify schemas

### DIFF
--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -3,36 +3,27 @@
   "$id": "https://linz.github.io/stac/__STAC_VERSION__/camera/schema.json",
   "title": "Camera Extension",
   "description": "STAC Camera Extension for STAC Items.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
-            "properties": {
-              "allOf": [
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
-              }
-            }
-          }
+      "type": "object",
+      "required": ["type", "properties", "assets"],
+      "properties": {
+        "type": {
+          "const": "Feature"
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
+        "properties": {
+          "$ref": "#/definitions/fields"
+        },
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
         }
-      ]
+      }
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
     }
   ],
   "definitions": {

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -3,40 +3,35 @@
   "$id": "https://linz.github.io/stac/__STAC_VERSION__/linz/schema.json",
   "title": "LINZ STAC Extension",
   "description": "LINZ STAC Extension.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for LINZ STAC Collections.",
-      "allOf": [
-        {
-          "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
+      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
+    },
+    {
+      "type": "object",
+      "required": ["title", "created", "updated"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
         },
-        {
-          "type": "object",
-          "required": ["title", "created", "updated"],
-          "properties": {
-            "title": {
-              "type": "string",
-              "minLength": 1
-            },
-            "created": {
-              "type": "string",
-              "minLength": 1,
-              "format": "date-time"
-            },
-            "updated": {
-              "type": "string",
-              "minLength": 1,
-              "format": "date-time"
-            }
-          }
+        "created": {
+          "type": "string",
+          "minLength": 1,
+          "format": "date-time"
         },
-        {
-          "$ref": "#/definitions/security_classification"
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
+        "updated": {
+          "type": "string",
+          "minLength": 1,
+          "format": "date-time"
         }
-      ]
+      }
+    },
+    {
+      "$ref": "#/definitions/security_classification"
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
     }
   ],
   "definitions": {

--- a/extensions/quality/schema.json
+++ b/extensions/quality/schema.json
@@ -2,24 +2,19 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://linz.github.io/stac/__STAC_VERSION__/quality/schema.json#",
   "description": "STAC Quality Extension for STAC Collections.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for LINZ STAC Collections.",
-      "allOf": [
-        {
-          "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
-        },
-        {
-          "type": "object",
-          "required": ["title"],
-          "properties": {
-            "title": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
+      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
+    },
+    {
+      "type": "object",
+      "required": ["title"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "minLength": 1
         }
-      ]
+      }
     }
   ],
   "definitions": {


### PR DESCRIPTION
`oneOf` and `anyOf` containing only one element are unnecessary.