### PR TITLE
docs: fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ if other data managers find them to be useful.
 
 ## Extensions
 
-- [Camera][./extensions/camera]: Camera details for photos.
+- [Camera](./extensions/camera): Camera details for photos.
 - [Historical Imagery](./extensions/historical_imagery): Aerial survey photos.
-- [LINZ][./extensions/linz]: Toitū Te Whenua LINZ-specific settings.
-- [Quality][./extensions/quality]: Dataset accuracy.
+- [LINZ](./extensions/linz): Toitū Te Whenua LINZ-specific settings.
+- [Quality](./extensions/quality): Dataset accuracy.
 
 ## Development
 


### PR DESCRIPTION
Noticed a typo in the markdown