### PR TITLE
feat: Create aerial photography extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ if other data managers find them to be useful.
 
 ## Extensions
 
+- [Aerial Photography](./extensions/aerial_photo): Aerial photography details for photos.
 - [Camera](./extensions/camera): Camera details for photos.
 - [Historical Imagery](./extensions/historical_imagery): Aerial survey photos.
 - [LINZ](./extensions/linz): Toitū Te Whenua LINZ-specific settings.

--- a/extensions/aerial_photo/README.md
+++ b/extensions/aerial_photo/README.md
@@ -1,0 +1,20 @@
+# Aerial Photography Extension Specification
+
+**This is a work in progress and has not been reviewed everything is likely to change**
+
+- **Title**: aerial_photo
+- **Identifier**:
+  [https://linz.github.io/stac/_STAC_VERSION_/film/aerial_photo.json]()
+- **Field Name Prefix**: aerial_photo
+- **Scope**: Item
+- **Extension Classification**: Work In Progress (Before proposal)
+
+## Item Properties or Asset Fields
+
+| Field Name                   | Type    | Description                                                                                                   |
+| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------- |
+| aerial_photo:run             | string  | **REQUIRED** A straight line/pass of sequential imagery flown during a specific survey.                       |
+| aerial_photo:altitude        | integer | Altitude in feet at which the plane was flying when the photo was taken.                                      |
+| aerial_photo:scale           | integer | Denominator of the distance on the ground relative to the distance on the physical film negative for a photo. |
+| aerial_photo:sequence_number | integer | **REQUIRED** Sequential order of photos taken during a run.                                                   |
+| aerial_photo:anomalies       | string  | Comments about unusual things noticed in the image.                                                           |

--- a/extensions/aerial_photo/examples/item.json
+++ b/extensions/aerial_photo/examples/item.json
@@ -1,0 +1,26 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"],
+  "type": "Feature",
+  "id": "72360",
+  "geometry": null,
+  "properties": {
+    "datetime": "1952-04-23T00:00:00.000Z",
+    "platform": "Fixed-wing Aircraft",
+    "instruments": ["EAGLE IV"],
+    "mission": "SURVEY_1",
+    "aerial_photo:run": "P1",
+    "aerial_photo:altitude": 3325,
+    "aerial_photo:scale": 4800,
+    "aerial_photo:sequence_number": 14,
+    "aerial_photo:anomalies": "Cloud shadow"
+  },
+  "links": [],
+  "assets": {
+    "image/tiff; application=geotiff; profile=cloud-optimized": {
+      "href": "./72360.tiff",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+    }
+  }
+}

--- a/extensions/aerial_photo/non-examples/no_run.json
+++ b/extensions/aerial_photo/non-examples/no_run.json
@@ -1,0 +1,26 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"],
+  "description": "This is a non-conformant STAC example using the aerial photography extension. It is missing the mandatory aerial_photo:run property.",
+  "type": "Feature",
+  "id": "72360",
+  "geometry": null,
+  "properties": {
+    "datetime": "1952-04-23T00:00:00.000Z",
+    "platform": "Fixed-wing Aircraft",
+    "instruments": ["EAGLE IV"],
+    "mission": "SURVEY_1",
+    "aerial_photo:altitude": 3325,
+    "aerial_photo:scale": 4800,
+    "aerial_photo:sequence_number": 14,
+    "aerial_photo:anomalies": "Cloud shadow"
+  },
+  "links": [],
+  "assets": {
+    "image/tiff; application=geotiff; profile=cloud-optimized": {
+      "href": "./72360.tiff",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+    }
+  }
+}

--- a/extensions/aerial_photo/non-examples/no_sequence_number.json
+++ b/extensions/aerial_photo/non-examples/no_sequence_number.json
@@ -1,0 +1,26 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"],
+  "description": "This is a non-conformant STAC example using the aerial photography extension. It is missing the mandatory aerial_photo:sequence_number property.",
+  "type": "Feature",
+  "id": "72360",
+  "geometry": null,
+  "properties": {
+    "datetime": "1952-04-23T00:00:00.000Z",
+    "platform": "Fixed-wing Aircraft",
+    "instruments": ["EAGLE IV"],
+    "mission": "SURVEY_1",
+    "aerial_photo:run": "P1",
+    "aerial_photo:altitude": 3325,
+    "aerial_photo:scale": 4800,
+    "aerial_photo:anomalies": "Cloud shadow"
+  },
+  "links": [],
+  "assets": {
+    "image/tiff; application=geotiff; profile=cloud-optimized": {
+      "href": "./72360.tiff",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+    }
+  }
+}

--- a/extensions/aerial_photo/non-examples/run_integer.json
+++ b/extensions/aerial_photo/non-examples/run_integer.json
@@ -1,0 +1,27 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"],
+  "description": "This is a non-conformant STAC example using the aerial photography extension. The aerial_photo:run field is an integer instead of a string.",
+  "type": "Feature",
+  "id": "72360",
+  "geometry": null,
+  "properties": {
+    "datetime": "1952-04-23T00:00:00.000Z",
+    "platform": "Fixed-wing Aircraft",
+    "instruments": ["EAGLE IV"],
+    "mission": "SURVEY_1",
+    "aerial_photo:run": 248,
+    "aerial_photo:altitude": 3325,
+    "aerial_photo:scale": 4800,
+    "aerial_photo:sequence_number": 14,
+    "aerial_photo:anomalies": "Cloud shadow"
+  },
+  "links": [],
+  "assets": {
+    "image/tiff; application=geotiff; profile=cloud-optimized": {
+      "href": "./72360.tiff",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+    }
+  }
+}

--- a/extensions/aerial_photo/non-examples/sequence_number_string.json
+++ b/extensions/aerial_photo/non-examples/sequence_number_string.json
@@ -1,0 +1,27 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"],
+  "description": "This is a non-conformant STAC example using the aerial photography extension. The aerial_photo:sequence_number field is a string instead of an integer.",
+  "type": "Feature",
+  "id": "72360",
+  "geometry": null,
+  "properties": {
+    "datetime": "1952-04-23T00:00:00.000Z",
+    "platform": "Fixed-wing Aircraft",
+    "instruments": ["EAGLE IV"],
+    "mission": "SURVEY_1",
+    "aerial_photo:run": "P1",
+    "aerial_photo:altitude": 3325,
+    "aerial_photo:scale": 4800,
+    "aerial_photo:sequence_number": "incorrect string",
+    "aerial_photo:anomalies": "Cloud shadow"
+  },
+  "links": [],
+  "assets": {
+    "image/tiff; application=geotiff; profile=cloud-optimized": {
+      "href": "./72360.tiff",
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130"
+    }
+  }
+}

--- a/extensions/aerial_photo/schema.json
+++ b/extensions/aerial_photo/schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json",
+  "title": "Aerial Photography Extension",
+  "description": "STAC Aerial Photography Extension for STAC Items.",
+  "allOf": [
+    {
+      "type": "object",
+      "required": ["type", "properties", "assets"],
+      "properties": {
+        "type": {
+          "const": "Feature"
+        },
+        "properties": {
+          "required": ["aerial_photo:run", "aerial_photo:sequence_number"],
+          "$ref": "#/definitions/fields"
+        },
+        "assets": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/fields"
+          }
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json"
+          }
+        }
+      }
+    },
+    "fields": {
+      "type": "object",
+      "properties": {
+        "aerial_photo:run": {
+          "title": "Straight line/pass of sequential imagery",
+          "type": "string"
+        },
+        "aerial_photo:altitude": {
+          "title": "Altitude in feet",
+          "type": "integer"
+        },
+        "aerial_photo:scale": {
+          "title": "Scale denominator",
+          "type": "integer"
+        },
+        "aerial_photo:sequence_number": {
+          "title": "Sequential order",
+          "type": "integer"
+        },
+        "aerial_photo:anomalies": {
+          "title": "Image anomalies",
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^(?!aerial_photo:)": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/extensions/aerial_photo/schema.json
+++ b/extensions/aerial_photo/schema.json
@@ -12,8 +12,14 @@
           "const": "Feature"
         },
         "properties": {
-          "required": ["aerial_photo:run", "aerial_photo:sequence_number"],
-          "$ref": "#/definitions/fields"
+          "allOf": [
+            {
+              "required": ["aerial_photo:run", "aerial_photo:sequence_number"]
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
         },
         "assets": {
           "type": "object",

--- a/validate.sh
+++ b/validate.sh
@@ -6,6 +6,7 @@ shopt -s failglob
 validator_command=(
     node_modules/.bin/stac-node-validator
     --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/template/schema.json=extensions/template/schema.json
+    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/aerial_photo/schema.json=extensions/aerial_photo/schema.json
     --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json=extensions/camera/schema.json
     --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
     --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json


### PR DESCRIPTION
Add the aerial photography `STAC` Extension, made up of a explanatory README, JSON Schema, examples and non-examples.