### PR TITLE
revert: reinstate stac_extensions schema definitions

### DIFF
--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -21,9 +21,24 @@
           }
         }
       }
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"
+          }
+        }
+      }
+    },
     "fields": {
       "type": "object",
       "properties": {

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -15,9 +15,24 @@
     },
     {
       "$ref": "#/definitions/linz"
+    },
+    {
+      "$ref": "#/definitions/stac_extensions"
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json"
+          }
+        }
+      }
+    },
     "linz": {
       "type": "object",
       "required": ["title", "linz:security_classification", "linz:created", "linz:updated"],

--- a/extensions/quality/schema.json
+++ b/extensions/quality/schema.json
@@ -11,6 +11,18 @@
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json"
+          }
+        }
+      }
+    },
     "quality": {
       "type": "object",
       "properties": {

--- a/extensions/template/schema.json
+++ b/extensions/template/schema.json
@@ -32,6 +32,9 @@
               }
             }
           }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
         }
       ]
     },
@@ -60,6 +63,9 @@
           }
         },
         {
+          "$ref": "#/definitions/stac_extensions"
+        },
+        {
           "$comment": "Remove this object if this extension does not define top-level fields for Collections.",
           "$ref": "#/definitions/fields"
         }
@@ -67,6 +73,18 @@
     }
   ],
   "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": ["stac_extensions"],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"
+          }
+        }
+      }
+    },
     "fields": {
       "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
       "type": "object",


### PR DESCRIPTION
ref: eb3d4943b34e8e7e000bb5a407d72a536c9ea22d (commit being reverted)
discussion: https://github.com/linz/stac/pull/60#discussion_r715257218
upstream issue: https://github.com/stac-extensions/template/issues/10

These appear to be useful for checking that our own examples are correct, and to remain consistent with all of the JSON Schemas in the STAC community extensions.

If they are removed upstream / determined to no longer be needed, then a new PR and discussion can be created.