### PR TITLE
Fix horizontal accuracy metadata

### DIFF
--- a/extensions/quality/README.md
+++ b/extensions/quality/README.md
@@ -15,9 +15,8 @@
 | Field Name                       | Type   | Description                                                                                                  |
 | -------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------ |
 | quality:description              | string | Information or description relating to the quality of the dataset.                                           |
-| quality:horizontal_accuracy      | number | The horizontal accuracy of the dataset. Must be in units of metres.                                          |
-| quality:horizontal_accuracy_type | string | The type of accuracy for the horizontal accuracy value. Options are "Nominal" and "95% confidence interval". |
-| quality:vertical_accuracy        | number | The vertical accuracy of the dataset. Must be in units of metres.                                            |
+| quality:horizontal_accuracy      | number | **REQUIRED**. The horizontal accuracy of the dataset. Must be in units of metres.                                          |
+| quality:horizontal_accuracy_type | string | **REQUIRED**. The type of accuracy for the horizontal accuracy value. Options are "Nominal" and "95% confidence interval". |
 | quality:lineage                  | string | **REQUIRED**. A descriptive statement about the lineage/history of a dataset                                 |
 | quality:vertical_accuracy        | number | The vertical accuracy of the dataset. Must be in units of metres.                                            |
 | quality:vertical_accuracy_type   | string | The type of accuracy for the vertical accuracy value. Options are "Nominal" and "95% confidence interval".   |


### PR DESCRIPTION
- horizontal accuracy metadata are supposed to be 'required'
- remove duplicated row for vertical_accuracy