### PR TITLE
feat: Support catalog in LINZ schema

### DIFF
--- a/extensions/aerial-photo/README.md
+++ b/extensions/aerial-photo/README.md
@@ -4,7 +4,7 @@
 
 - **Title**: Aerial Photography
 - **Identifier**:
-  <https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/aerial-photo/schema.json>
 - **Field Name Prefix**: aerial-photo
 - **Scope**: Item
 - **Extension Classification**: Work In Progress (Before proposal)

--- a/extensions/aerial-photo/examples/item.json
+++ b/extensions/aerial-photo/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json"],
+  "stac_extensions": ["https://linz.github.io/stac/extensions/_STAC_VERSION_/aerial-photo/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,

--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/aerial-photo/schema.json",
   "title": "Aerial Photography Extension",
   "description": "STAC Aerial Photography Extension for STAC Items.",
   "allOf": [
@@ -41,7 +41,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/aerial-photo/schema.json"
           }
         }
       }

--- a/extensions/aerial-photo/tests/aerial_photo_item.test.js
+++ b/extensions/aerial-photo/tests/aerial_photo_item.test.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/camera/README.md
+++ b/extensions/camera/README.md
@@ -5,7 +5,7 @@ change**
 
 - **Title**: Camera
 - **Identifier**:
-  <https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/camera/schema.json>
 - **Field Name Prefix**: camera
 - **Scope**: Item
 - **Extension Classification**: Work In Progress (Before proposal)

--- a/extensions/camera/examples/item.json
+++ b/extensions/camera/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"],
+  "stac_extensions": ["https://linz.github.io/stac/extensions/_STAC_VERSION_/camera/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,

--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/camera/schema.json",
   "title": "Camera Extension",
   "description": "STAC Camera Extension for STAC Items.",
   "allOf": [
@@ -34,7 +34,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/camera/schema.json"
           }
         }
       }

--- a/extensions/film/README.md
+++ b/extensions/film/README.md
@@ -4,7 +4,7 @@
 
 - **Title**: Film
 - **Identifier**:
-  <https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/film/schema.json>
 - **Field Name Prefix**: film
 - **Scope**: Item
 - **Extension Classification**: Work In Progress (Before proposal)

--- a/extensions/film/examples/item.json
+++ b/extensions/film/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/film/schema.json"],
+  "stac_extensions": ["https://linz.github.io/stac/extensions/_STAC_VERSION_/film/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,

--- a/extensions/film/schema.json
+++ b/extensions/film/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/film/schema.json",
   "title": "Film Extension",
   "description": "STAC Film Extension for STAC Items.",
   "allOf": [
@@ -41,7 +41,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/film/schema.json"
           }
         }
       }

--- a/extensions/film/tests/film.test.js
+++ b/extensions/film/tests/film.test.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -2,7 +2,7 @@
 
 - **Title:** LINZ Top Level Extension
 - **Identifier:**
-  <https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/linz/schema.json>
 - **Field Name Prefix:** linz
 - **Scope:** Item, Collection
 - **Extension

--- a/extensions/linz/examples/collection.json
+++ b/extensions/linz/examples/collection.json
@@ -1,8 +1,8 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"

--- a/extensions/linz/examples/item.json
+++ b/extensions/linz/examples/item.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json",
   "title": "LINZ STAC Extension",
   "description": "LINZ STAC Extension.",
   "allOf": [
@@ -33,7 +33,7 @@
               "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
             },
             {
-              "$ref": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json#"
+              "$ref": "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json#"
             }
           ]
         },
@@ -60,7 +60,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json"
           }
         }
       }

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -27,10 +27,19 @@
           "allOf": [
             {
               "type": "object",
-              "required": ["linz:lifecycle", "linz:providers", "linz:security_classification", "providers", "title"]
-            },
-            {
-              "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
+              "required": [
+                "linz:lifecycle",
+                "linz:providers",
+                "linz:security_classification",
+                "providers",
+                "title",
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "const": "Collection"
+                }
+              }
             },
             {
               "$ref": "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json#"
@@ -38,16 +47,13 @@
           ]
         },
         {
-          "$comment": "This is the schema for STAC Items.",
-          "allOf": [
-            {
-              "type": "object",
-              "required": ["linz:geospatial_type"]
-            },
-            {
-              "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#"
+          "type": "object",
+          "required": ["linz:geospatial_type", "type"],
+          "properties": {
+            "type": {
+              "const": "Feature"
             }
-          ]
+          }
         }
       ]
     }
@@ -223,7 +229,8 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/geospatial_type_enum"
-              }
+              },
+              "minItems": 1
             }
           }
         },

--- a/extensions/linz/tests/linz_collection.test.js
+++ b/extensions/linz/tests/linz_collection.test.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/linz/tests/linz_item.test.js
+++ b/extensions/linz/tests/linz_item.test.js
@@ -1,5 +1,5 @@
 import o from 'ospec';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';

--- a/extensions/quality/README.md
+++ b/extensions/quality/README.md
@@ -2,7 +2,7 @@
 
 - **Title**: Quality
 - **Identifier**:
-  <https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/quality/schema.json>
 - **Field Name Prefix**: quality
 - **Scope**: Collection
 - **Extension

--- a/extensions/quality/examples/collection.json
+++ b/extensions/quality/examples/collection.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json"
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json"
   ],
   "type": "Collection",
   "id": "collection",

--- a/extensions/quality/schema.json
+++ b/extensions/quality/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json#",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json#",
   "description": "STAC Quality Extension for STAC Collections.",
   "allOf": [
     {
@@ -21,7 +21,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json"
           }
         }
       }

--- a/extensions/quality/schema.json
+++ b/extensions/quality/schema.json
@@ -4,9 +4,6 @@
   "description": "STAC Quality Extension for STAC Collections.",
   "allOf": [
     {
-      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
-    },
-    {
       "$ref": "#/definitions/stac_extensions"
     },
     {
@@ -28,7 +25,7 @@
     },
     "quality": {
       "type": "object",
-      "required": ["quality:lineage"],
+      "required": ["quality:lineage", "type"],
       "properties": {
         "quality:description": {
           "title": "Dataset Data Quality",
@@ -55,6 +52,9 @@
           "title": "Vertical Accuracy Type",
           "type": "string",
           "enum": ["nominal", "95% confidence interval"]
+        },
+        "type": {
+          "const": "Collection"
         }
       },
       "patternProperties": {

--- a/extensions/quality/tests/quality_collection.test.js
+++ b/extensions/quality/tests/quality_collection.test.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/scanning/README.md
+++ b/extensions/scanning/README.md
@@ -5,7 +5,7 @@ change**
 
 - **Title**: Scanning
 - **Identifier**:
-  <https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/scanning/schema.json>
 - **Field Name Prefix**: scan
 - **Scope**: Item
 - **Extension Classification**: Work In Progress (Before proposal)

--- a/extensions/scanning/examples/item.json
+++ b/extensions/scanning/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"],
+  "stac_extensions": ["https://linz.github.io/stac/extensions/_STAC_VERSION_/scanning/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,

--- a/extensions/scanning/schema.json
+++ b/extensions/scanning/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/scanning/schema.json",
   "title": "Scanning Extension",
   "description": "STAC Scanning Extension for STAC Items.",
   "allOf": [
@@ -34,7 +34,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/scanning/schema.json"
           }
         }
       }

--- a/extensions/template/README.md
+++ b/extensions/template/README.md
@@ -2,7 +2,7 @@
 
 - **Title:** Template
 - **Identifier:**
-  <https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json>
+  <https://stac.linz.govt.nz/extensions/_STAC_VERSION_/template/schema.json>
 - **Field Name Prefix:** template
 - **Scope:** Item, Collection
 - **Extension

--- a/extensions/template/examples/collection.json
+++ b/extensions/template/examples/collection.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/template/schema.json"
   ],
   "type": "Collection",
   "id": "collection",

--- a/extensions/template/examples/item.json
+++ b/extensions/template/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"],
+  "stac_extensions": ["https://linz.github.io/stac/extensions/_STAC_VERSION_/template/schema.json"],
   "type": "Feature",
   "id": "item",
   "bbox": [172.9, 1.3, 173, 1.4],

--- a/extensions/template/schema.json
+++ b/extensions/template/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json",
+  "$id": "https://linz.github.io/stac/extensions/_STAC_VERSION_/template/schema.json",
   "title": "Template Extension",
   "description": "STAC Template Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -134,7 +134,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"
+            "const": "https://linz.github.io/stac/extensions/_STAC_VERSION_/template/schema.json"
           }
         }
       }

--- a/extensions/template/tests/template_item.test.js
+++ b/extensions/template/tests/template_item.test.js
@@ -3,7 +3,7 @@ import Ajv from 'ajv';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/validation.js
+++ b/extensions/validation.js
@@ -21,8 +21,8 @@ export function loadSchema(uri) {
  */
 export async function loadSchemaFromUri(uri) {
   try {
-    if (uri.startsWith('https://linz.github.io/stac/_STAC_VERSION_/')) {
-      const schemaPath = uri.slice('https://linz.github.io/stac/_STAC_VERSION_/'.length);
+    if (uri.startsWith('https://linz.github.io/stac/extensions/_STAC_VERSION_/')) {
+      const schemaPath = uri.slice('https://linz.github.io/stac/extensions/_STAC_VERSION_/'.length);
       return JSON.parse(await fs.readFile(join(__dirname, schemaPath)));
     }
 

--- a/schemas/linz/CHANGELOG.md
+++ b/schemas/linz/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+[unreleased]: https://github.com/stac/schemas/linz/compare/v1.0.0...HEAD

--- a/schemas/linz/README.md
+++ b/schemas/linz/README.md
@@ -1,0 +1,37 @@
+# LINZ Top Level Schema Specification
+
+- **Title:** LINZ Top Level Schema
+- **Identifier:**
+  <https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json>
+- **Scope:** Catalog, Collection, Item
+- **Extension
+  [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):**
+  Proposal
+- **Owner**: @billgeo @imincik @l0b0 @MitchellPaff
+
+This is LINZ top level
+[SpatioTemporal Asset Catalog](https://github.com/radiantearth/stac-spec) (STAC)
+schema which adds constraints to default STAC schema properties.
+
+- Examples:
+
+  - [Catalog example](examples/catalog.json): Shows the basic usage of the
+    extension in a STAC Catalog
+  - [Collection example](examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+  - [Item example](examples/item.json): Shows the basic usage of the extension
+    in a STAC Item
+
+- [JSON Schema](./schema.json)
+- [Changelog](./CHANGELOG.md)
+
+## Fields
+
+See the referenced [LINZ extension](../../extensions/linz) and the upstream [Catalog schema](https://github.com/radiantearth/stac-spec/blob/v1.0.0/catalog-spec/catalog-spec.md).
+
+## Contributing
+
+All contributions are subject to the
+[STAC Specification Code of Conduct](https://github.com/radiantearth/stac-spec/blob/master/CODE_OF_CONDUCT.md).
+For contributions, please follow the
+[STAC specification contributing guide](https://github.com/radiantearth/stac-spec/blob/master/CONTRIBUTING.md).

--- a/schemas/linz/examples/catalog.json
+++ b/schemas/linz/examples/catalog.json
@@ -1,0 +1,8 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": ["https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json"],
+  "type": "Catalog",
+  "id": "catalog",
+  "description": "A description",
+  "links": []
+}

--- a/schemas/linz/examples/collection.json
+++ b/schemas/linz/examples/collection.json
@@ -1,0 +1,84 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json",
+    "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+  ],
+  "type": "Collection",
+  "id": "collection",
+  "title": "A title",
+  "description": "A description",
+  "license": "Apache-2.0",
+  "linz:lifecycle": "under development",
+  "linz:providers": [
+    {
+      "name": "Example",
+      "description": "Example description.",
+      "roles": ["custodian"],
+      "url": "https://www.exampleurl.com"
+    },
+    {
+      "name": "Example",
+      "description": "Example description.",
+      "roles": ["manager"],
+      "url": "https://www.exampleurl.com"
+    }
+  ],
+  "linz:security_classification": "unclassified",
+  "extent": {
+    "spatial": {
+      "bbox": [[172.9, 1.3, 173, 1.4]]
+    },
+    "temporal": {
+      "interval": [["2015-06-23T00:00:00Z", null]]
+    }
+  },
+  "summaries": {
+    "created": {
+      "minimum": "1999-01-01T00:00:00Z",
+      "maximum": "2010-01-01T00:00:00Z"
+    },
+    "updated": {
+      "minimum": "1999-01-02T00:00:00Z",
+      "maximum": "2010-01-02T00:00:00Z"
+    },
+    "datetime": {
+      "minimum": "2015-06-23T00:00:00Z",
+      "maximum": "2019-07-10T13:44:56Z"
+    },
+    "linz:geospatial_type": ["polygon"]
+  },
+  "links": [],
+  "quality:description": "Example quality description",
+  "quality:horizontal_accuracy": 1,
+  "quality:horizontal_accuracy_type": "nominal",
+  "quality:lineage": "This is an example dataset lineage description.",
+  "providers": [
+    {
+      "name": "Example",
+      "description": "Example description.",
+      "roles": ["licensor"],
+      "url": "https://www.exampleurl.com"
+    },
+    {
+      "name": "Example",
+      "description": "Example description.",
+      "roles": ["producer"],
+      "url": "https://www.exampleurl.com"
+    }
+  ],
+  "version": "2.0.0",
+  "assets": {
+    "example": {
+      "href": "https://example.com/examples/file.xyz",
+      "created": "2000-01-01T00:00:00Z",
+      "updated": "2020-01-01T00:00:00Z",
+      "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "proj:epsg": 32659
+    }
+  }
+}

--- a/schemas/linz/examples/item.json
+++ b/schemas/linz/examples/item.json
@@ -1,0 +1,45 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json",
+    "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json",
+    "https://stac-extensions.github.io/file/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "item",
+  "bbox": [172.9, 1.3, 173, 1.4],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [172.9, 1.3],
+        [173, 1.3],
+        [173, 1.4],
+        [172.9, 1.4],
+        [172.9, 1.3]
+      ]
+    ]
+  },
+  "properties": {
+    "datetime": "2020-12-11T22:38:32Z",
+    "proj:epsg": 123,
+    "version": "1.0.0"
+  },
+  "links": [
+    {
+      "href": "https://example.com/examples/item.json",
+      "rel": "self"
+    }
+  ],
+  "assets": {
+    "example": {
+      "href": "https://example.com/examples/file.xyz",
+      "created": "2000-01-01T00:00:00Z",
+      "updated": "2020-01-01T00:00:00Z",
+      "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    }
+  },
+  "linz:geospatial_type": "polygon"
+}

--- a/schemas/linz/schema.json
+++ b/schemas/linz/schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json",
+  "title": "LINZ STAC Schema",
+  "description": "LINZ STAC Schema.",
+  "oneOf": [
+    {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json#"
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json#"
+        },
+        {
+          "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json#"
+        },
+        {
+          "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#"
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/linz/tests/linz_catalog.test.js
+++ b/schemas/linz/tests/linz_catalog.test.js
@@ -7,9 +7,9 @@ import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');
-const examplePath = join(__dirname, '..', 'examples/collection.json');
+const examplePath = join(__dirname, '..', 'examples/catalog.json');
 
-o.spec('Template collection', () => {
+o.spec('LINZ catalog schema', () => {
   o.specTimeout(DefaultTimeoutMillis);
   let validate;
   const ajv = new Ajv(AjvOptions);
@@ -24,26 +24,9 @@ o.spec('Template collection', () => {
     const example = JSON.parse(await fs.readFile(examplePath));
 
     // when
-    let valid = validate(example);
+    const valid = validate(example);
 
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
-  });
-
-  o("Example without mandatory 'template:new_field' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example['template:new_field'];
-    delete example['assets'];
-    delete example['item_assets'];
-
-    // when
-    let valid = validate(example);
-
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some((error) => error.message === 'should match some schema in anyOf' && error.dataPath === ''),
-    ).equals(true)(JSON.stringify(validate.errors));
   });
 });

--- a/schemas/linz/tests/linz_collection.test.js
+++ b/schemas/linz/tests/linz_collection.test.js
@@ -9,7 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');
 const examplePath = join(__dirname, '..', 'examples/collection.json');
 
-o.spec('Template collection', () => {
+o.spec('LINZ collection schema', () => {
   o.specTimeout(DefaultTimeoutMillis);
   let validate;
   const ajv = new Ajv(AjvOptions);
@@ -24,26 +24,9 @@ o.spec('Template collection', () => {
     const example = JSON.parse(await fs.readFile(examplePath));
 
     // when
-    let valid = validate(example);
+    const valid = validate(example);
 
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
-  });
-
-  o("Example without mandatory 'template:new_field' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example['template:new_field'];
-    delete example['assets'];
-    delete example['item_assets'];
-
-    // when
-    let valid = validate(example);
-
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some((error) => error.message === 'should match some schema in anyOf' && error.dataPath === ''),
-    ).equals(true)(JSON.stringify(validate.errors));
   });
 });

--- a/schemas/linz/tests/linz_item.test.js
+++ b/schemas/linz/tests/linz_item.test.js
@@ -1,15 +1,15 @@
 import o from 'ospec';
-import Ajv from 'ajv';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { promises as fs } from 'fs';
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import Ajv from 'ajv';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');
 const examplePath = join(__dirname, '..', 'examples/item.json');
 
-o.spec('Camera item', () => {
+o.spec('LINZ item schema', () => {
   o.specTimeout(DefaultTimeoutMillis);
   let validate;
   const ajv = new Ajv(AjvOptions);
@@ -24,26 +24,9 @@ o.spec('Camera item', () => {
     const example = JSON.parse(await fs.readFile(examplePath));
 
     // when
-    let valid = validate(example);
+    const valid = validate(example);
 
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
-  });
-
-  o("Example with an incorrect 'camera:sequence_number' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.properties['camera:sequence_number'] = 'incorrect_value';
-
-    // when
-    let valid = validate(example);
-
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.dataPath === ".properties['camera:sequence_number']" && error.message === 'should be integer',
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
   });
 });

--- a/validate.sh
+++ b/validate.sh
@@ -5,12 +5,12 @@ shopt -s failglob
 
 validator_command=(
     node_modules/.bin/stac-node-validator
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/template/schema.json=extensions/template/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json=extensions/aerial-photo/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json=extensions/camera/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/film/schema.json=extensions/film/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/template/schema.json=extensions/template/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/aerial-photo/schema.json=extensions/aerial-photo/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/camera/schema.json=extensions/camera/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/film/schema.json=extensions/film/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
+    --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
 )
 "${validator_command[@]}" extensions/*/examples/*.json

--- a/validate.sh
+++ b/validate.sh
@@ -12,6 +12,7 @@ validator_command=(
     --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
     --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
     --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
+    --schemaMap=https://linz.github.io/stac/schemas/_STAC_VERSION_/linz/schema.json=schemas/linz/schema.json
 )
 
 "${validator_command[@]}" ./**/examples/*.json

--- a/validate.sh
+++ b/validate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -o errexit -o nounset
-shopt -s failglob
+shopt -s failglob globstar
 
 validator_command=(
     node_modules/.bin/stac-node-validator
@@ -13,4 +13,5 @@ validator_command=(
     --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
     --schemaMap=https://linz.github.io/stac/extensions/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
 )
-"${validator_command[@]}" extensions/*/examples/*.json
+
+"${validator_command[@]}" ./**/examples/*.json

--- a/validation.js
+++ b/validation.js
@@ -21,9 +21,12 @@ export function loadSchema(uri) {
  */
 export async function loadSchemaFromUri(uri) {
   try {
-    if (uri.startsWith('https://linz.github.io/stac/extensions/_STAC_VERSION_/')) {
-      const schemaPath = uri.slice('https://linz.github.io/stac/extensions/_STAC_VERSION_/'.length);
-      return JSON.parse(await fs.readFile(join(__dirname, schemaPath)));
+    for (const type of ['extensions', 'schemas']) {
+      const prefix = 'https://linz.github.io/stac/' + type + '/_STAC_VERSION_/';
+      if (uri.startsWith(prefix)) {
+        const schemaPath = join(type, uri.slice(prefix.length));
+        return JSON.parse(await fs.readFile(join(__dirname, schemaPath)));
+      }
     }
 
     let response = await axios.get(uri);


### PR DESCRIPTION
It just delegates to the upstream catalog schema for now, but this makes
it easier to extend the LINZ schema to support catalogs and allows
consumers like Geostore to use a single schema for all STAC objects.