### PR TITLE
fix: references updated to stac.linz.govt.nz and extension fixes - IGNORE

### DIFF
--- a/extensions/aerial-photo/examples/item.json
+++ b/extensions/aerial-photo/examples/item.json
@@ -1,11 +1,11 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,
   "properties": {
-    "datetime": "1952-04-23T00:00:00.000Z",
+    "datetime": "1952-04-22T12:00:00Z",
     "platform": "Fixed-wing Aircraft",
     "instruments": ["EAGLE IV"],
     "mission": "SURVEY_1",

--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json",
   "title": "Aerial Photography Extension",
   "description": "STAC Aerial Photography Extension for STAC Items.",
   "allOf": [
@@ -41,7 +41,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json"
           }
         }
       }

--- a/extensions/camera/README.md
+++ b/extensions/camera/README.md
@@ -14,5 +14,5 @@ change**
 
 | Field Name                  | Type    | Description                                                                                                                      |
 | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| camera:sequence_number      | integer | Also referred to as vender; the sequential order of photos taken by an individual camera                                         |
+| camera:sequence_number      | integer | The sequential order of photos taken by an individual camera                                                                     |
 | camera:nominal_focal_length | integer | Distance in mm from the camera lens centre to the film in the camera at which the image will have the least possible distortion. |

--- a/extensions/camera/examples/item.json
+++ b/extensions/camera/examples/item.json
@@ -1,11 +1,11 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,
   "properties": {
-    "datetime": "1952-04-23T00:00:00.000Z",
+    "datetime": "1952-04-22T12:00:00Z",
     "platform": "Fixed-wing Aircraft",
     "instruments": ["EAGLE IV"],
     "mission": "SURVEY_1",

--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json",
   "title": "Camera Extension",
   "description": "STAC Camera Extension for STAC Items.",
   "allOf": [
@@ -34,7 +34,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json"
           }
         }
       }

--- a/extensions/film/examples/item.json
+++ b/extensions/film/examples/item.json
@@ -1,11 +1,11 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/film/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,
   "properties": {
-    "datetime": "1952-04-23T00:00:00.000Z",
+    "datetime": "1952-04-22T12:00:00Z",
     "platform": "Fixed-wing Aircraft",
     "instruments": ["EAGLE IV"],
     "mission": "SURVEY_1",

--- a/extensions/film/schema.json
+++ b/extensions/film/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json",
   "title": "Film Extension",
   "description": "STAC Film Extension for STAC Items.",
   "allOf": [
@@ -41,7 +41,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json"
           }
         }
       }

--- a/extensions/historical-imagery/README.md
+++ b/extensions/historical-imagery/README.md
@@ -5,7 +5,7 @@ change**
 
 - **Title**: Historical Imagery
 - **Identifier**: <https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json>
-- **Field Name Prefix**: historical-imagery
+- **Field Name Prefix**: N/A
 - **Scope**: Item, Collection
 - **Extension Maturity Classification**: Work In Progress (Before proposal)
 

--- a/extensions/historical-imagery/examples/collection.json
+++ b/extensions/historical-imagery/examples/collection.json
@@ -1,7 +1,7 @@
 {
   "type": "Collection",
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json"],
   "id": "01FJ0SE46TT5TGBHBVX64TMEPA",
   "title": "399",
   "description": "Survey 399 of the Crown Aerial Film Archive",
@@ -11,7 +11,7 @@
       "bbox": [[170.54524, -45.80237, 170.56431, -45.81345]]
     },
     "temporal": {
-      "interval": [["1947-03-28T12:00:00.000Z", "1952-04-22T12:00:00.000Z"]]
+      "interval": [["1947-03-28T12:00:00Z", "1952-04-22T12:00:00Z"]]
     }
   },
   "providers": [
@@ -78,8 +78,8 @@
       }
     ],
     "scan:scanned": {
-      "minimum": "2018-06-30T12:00:00.000Z",
-      "maximum": "2019-12-31T12:00:00.000Z"
+      "minimum": "2018-06-30T12:00:00Z",
+      "maximum": "2019-12-31T11:00:00Z"
     },
     "proj:epsg": {
       "minimum": 2193,

--- a/extensions/historical-imagery/examples/item.json
+++ b/extensions/historical-imagery/examples/item.json
@@ -1,14 +1,14 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"
+    "https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json"
   ],
   "type": "Feature",
   "id": "215354",
@@ -26,7 +26,7 @@
     ]
   },
   "properties": {
-    "datetime": "1949-03-09T12:00:00.000Z",
+    "datetime": "1949-03-09T12:00:00Z",
     "platform": "Fixed-wing Aircraft",
     "instruments": ["EAGLE IV"],
     "mission": "399",
@@ -44,7 +44,7 @@
     "film:physical_condition": "Film scratched",
     "film:physical_size": "18cm x 23cm",
     "scan:is_original": true,
-    "scan:scanned": "2018-09-30T12:00:00.000Z"
+    "scan:scanned": "2018-09-30T11:00:00Z"
   },
   "links": [
     {

--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json",
   "title": "Historical Imagery Extension",
   "description": "STAC Historical Imagery Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -21,10 +21,7 @@
             },
             "assets": {
               "type": "object",
-              "$comment": "Require fields here for Item Asset Properties.",
-              "additionalProperties": {
-                "required": ["eo:bands"]
-              }
+              "$comment": "Require fields here for Item Asset Properties."
             }
           }
         },
@@ -64,7 +61,7 @@
           "allOf": [
             {
               "contains": {
-                "const": "https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json"
+                "const": "https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json"
               }
             },
             {
@@ -84,22 +81,22 @@
             },
             {
               "contains": {
-                "const": "https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json"
+                "const": "https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json"
               }
             },
             {
               "contains": {
-                "const": "https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json"
+                "const": "https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json"
               }
             },
             {
               "contains": {
-                "const": "https://linz.github.io/stac/_STAC_VERSION_/film/schema.json"
+                "const": "https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json"
               }
             },
             {
               "contains": {
-                "const": "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"
+                "const": "https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json"
               }
             }
           ]
@@ -113,7 +110,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json"
           }
         }
       }

--- a/extensions/linz/examples/collection.json
+++ b/extensions/linz/examples/collection.json
@@ -1,8 +1,8 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"

--- a/extensions/linz/examples/item.json
+++ b/extensions/linz/examples/item.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
+    "https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json",
     "https://stac-extensions.github.io/file/v2.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/version/v1.0.0/schema.json"

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json",
   "title": "LINZ STAC Extension",
   "description": "LINZ STAC Extension.",
   "allOf": [
@@ -46,7 +46,7 @@
               "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json#"
             },
             {
-              "$ref": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json#"
+              "$ref": "https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json#"
             }
           ]
         },
@@ -78,7 +78,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json"
           }
         }
       }

--- a/extensions/quality/examples/collection.json
+++ b/extensions/quality/examples/collection.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json"
+    "https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json"
   ],
   "type": "Collection",
   "id": "collection",

--- a/extensions/quality/schema.json
+++ b/extensions/quality/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json#",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json#",
   "description": "STAC Quality Extension for STAC Collections.",
   "allOf": [
     {
@@ -21,7 +21,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json"
           }
         }
       }

--- a/extensions/scanning/examples/item.json
+++ b/extensions/scanning/examples/item.json
@@ -1,16 +1,16 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json"],
   "type": "Feature",
   "id": "72360",
   "geometry": null,
   "properties": {
-    "datetime": "1952-04-23T00:00:00.000Z",
+    "datetime": "1952-04-22T12:00:00Z",
     "platform": "Fixed-wing Aircraft",
     "instruments": ["EAGLE IV"],
     "mission": "SURVEY_1",
     "scan:is_original": true,
-    "scan:scanned": "2018-10-01T00:00:00.000Z"
+    "scan:scanned": "2018-09-30T11:00:00Z"
   },
   "links": [],
   "assets": {

--- a/extensions/scanning/schema.json
+++ b/extensions/scanning/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json",
   "title": "Scanning Extension",
   "description": "STAC Scanning Extension for STAC Items.",
   "allOf": [
@@ -34,7 +34,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json"
           }
         }
       }
@@ -49,6 +49,7 @@
         "scan:scanned": {
           "title": "Scanned Date",
           "type": "string",
+          "format": "date-time",
           "pattern": "(\\+00:00|Z)$"
         }
       },

--- a/extensions/scanning/tests/scanning.test.js
+++ b/extensions/scanning/tests/scanning.test.js
@@ -9,7 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');
 const examplePath = join(__dirname, '..', 'examples/item.json');
 
-o.spec('historical-imagery item', () => {
+o.spec('Scanning item', () => {
   o.specTimeout(DefaultTimeoutMillis);
   let validate;
   const ajv = new Ajv(AjvOptions);
@@ -24,16 +24,17 @@ o.spec('historical-imagery item', () => {
     const example = JSON.parse(await fs.readFile(examplePath));
 
     // when
-    const valid = validate(example);
+    let valid = validate(example);
 
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  o("Example without mandatory 'mission' property should fail validation", async () => {
+  o("Example with an incorrect 'scan:is_original' field should fail validation", async () => {
     // given
     const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.properties['mission'];
+    example.properties['scan:is_original'] = 'notboolean';
+
     // when
     let valid = validate(example);
 
@@ -41,15 +42,16 @@ o.spec('historical-imagery item', () => {
     o(valid).equals(false);
     o(
       validate.errors.some(
-        (error) => error.dataPath === '.properties' && error.message === "should have required property '.mission'",
+        (error) => error.dataPath === ".properties['scan:is_original']" && error.message === 'should be boolean',
       ),
     ).equals(true)(JSON.stringify(validate.errors));
   });
 
-  o("Example without mandatory 'platform' property should fail validation", async () => {
+  o("Example with an incorrect 'scan:scanned' field should fail validation", async () => {
     // given
     const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.properties['platform'];
+    example.properties['scan:scanned'] = '2019/DQ';
+
     // when
     let valid = validate(example);
 
@@ -57,7 +59,8 @@ o.spec('historical-imagery item', () => {
     o(valid).equals(false);
     o(
       validate.errors.some(
-        (error) => error.dataPath === '.properties' && error.message === "should have required property '.platform'",
+        (error) =>
+          error.dataPath === ".properties['scan:scanned']" && error.message === 'should match pattern "(\\+00:00|Z)$"',
       ),
     ).equals(true)(JSON.stringify(validate.errors));
   });

--- a/extensions/template/examples/collection.json
+++ b/extensions/template/examples/collection.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"
+    "https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json"
   ],
   "type": "Collection",
   "id": "collection",

--- a/extensions/template/examples/item.json
+++ b/extensions/template/examples/item.json
@@ -1,6 +1,6 @@
 {
   "stac_version": "1.0.0",
-  "stac_extensions": ["https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"],
+  "stac_extensions": ["https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json"],
   "type": "Feature",
   "id": "item",
   "bbox": [172.9, 1.3, 173, 1.4],

--- a/extensions/template/schema.json
+++ b/extensions/template/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json",
+  "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json",
   "title": "Template Extension",
   "description": "STAC Template Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -134,7 +134,7 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://linz.github.io/stac/_STAC_VERSION_/template/schema.json"
+            "const": "https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json"
           }
         }
       }

--- a/validate.sh
+++ b/validate.sh
@@ -5,14 +5,14 @@ shopt -s failglob globstar
 
 validator_command=(
     node_modules/.bin/stac-node-validator
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/template/schema.json=extensions/template/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/historical-imagery/schema.json=extensions/historical-imagery/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/aerial-photo/schema.json=extensions/aerial-photo/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/camera/schema.json=extensions/camera/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/film/schema.json=extensions/film/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
-    --schemaMap=https://linz.github.io/stac/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/template/schema.json=extensions/template/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json=extensions/historical-imagery/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json=extensions/aerial-photo/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json=extensions/camera/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json=extensions/film/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json=extensions/scanning/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json=extensions/quality/schema.json
+    --schemaMap=https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json=extensions/linz/schema.json
 )
 
 "${validator_command[@]}" ./**/examples/*.json

--- a/validation.js
+++ b/validation.js
@@ -21,8 +21,8 @@ export function loadSchema(uri) {
  */
 export async function loadSchemaFromUri(uri) {
   try {
-    if (uri.startsWith('https://linz.github.io/stac/_STAC_VERSION_/')) {
-      const schemaPath = uri.slice('https://linz.github.io/stac/_STAC_VERSION_/'.length);
+    if (uri.startsWith('https://stac.linz.govt.nz/_STAC_VERSION_/')) {
+      const schemaPath = uri.slice('https://stac.linz.govt.nz/_STAC_VERSION_/'.length);
       return JSON.parse(await fs.readFile(join(__dirname, 'extensions', schemaPath)));
     }
 


### PR DESCRIPTION
**Changes:**

- Update all references to linz.github.io/stac to be stac.linz.govt.nz.
- Do not require eo:bands asset field in Historical Imagery extension.
- Update example dates to be in NZ timezone taking daylight savings into account.
- Remove milliseconds from example datetimes.
- Remove reference to 'vender' in Camera extension Readme (probably 'veder' or 'veeder' but not meaningful to other organisations.
- Added tests for Scanning extension.
- Specify date-time format in Scanning extension to match STAC schema.