### PR TITLE
fix(historical-imagery): remove eo:bands in schema and test (TDE-207)

### DIFF
--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -21,10 +21,7 @@
             },
             "assets": {
               "type": "object",
-              "$comment": "Require fields here for Item Asset Properties.",
-              "additionalProperties": {
-                "required": ["eo:bands"]
-              }
+              "$comment": "Require fields here for Item Asset Properties."
             }
           }
         },

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.js
@@ -61,23 +61,4 @@ o.spec('historical-imagery item', () => {
       ),
     ).equals(true)(JSON.stringify(validate.errors));
   });
-
-  o("Example without the mandatory 'eo:bands' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.assets['image/tiff; application=geotiff; profile=cloud-optimized']['eo:bands'];
-
-    // when
-    let valid = validate(example);
-
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) =>
-          error.dataPath === ".assets['image/tiff; application=geotiff; profile=cloud-optimized']" &&
-          error.message === "should have required property '['eo:bands']'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
 });


### PR DESCRIPTION
_Moved to draft as maybe we do want this after all..._

- Do not require eo:bands asset field in Historical Imagery extension.
- Remove associated test.