### PR TITLE
feat: Add new optional linz:language and linz:encoding fields to the …

### DIFF
--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -104,6 +104,8 @@ These fields apply to assets within both items and collections.
 | assets/\*/created       | string | **REQUIRED**. Creation date and time of the asset, in UTC.                                              |
 | assets/\*/updated       | string | **REQUIRED**. Date and time the asset was last updated, in UTC.                                         |
 | assets/\*/file:checksum | string | **REQUIRED**. See [reference](https://github.com/stac-extensions/file/blob/v2.0.0/README.md#checksums). |
+| linz:encoding           | string | Recommended. Character encoding standard used for the data asset.                                       |
+| linz:language           | string | Recommended. Language used in the data asset.                                                           |
 
 ## Extensions
 

--- a/extensions/linz/examples/collection.json
+++ b/extensions/linz/examples/collection.json
@@ -79,7 +79,7 @@
       "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "proj:epsg": 32659,
       "linz:encoding": "utf-8",
-      "linz:language": "en_NZ"
+      "linz:language": "en-NZ"
     }
   }
 }

--- a/extensions/linz/examples/collection.json
+++ b/extensions/linz/examples/collection.json
@@ -77,7 +77,9 @@
       "created": "2000-01-01T00:00:00Z",
       "updated": "2020-01-01T00:00:00Z",
       "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "proj:epsg": 32659
+      "proj:epsg": 32659,
+      "linz:encoding": "utf-8",
+      "linz:language": "en_NZ"
     }
   }
 }

--- a/extensions/linz/examples/item.json
+++ b/extensions/linz/examples/item.json
@@ -37,7 +37,9 @@
       "href": "https://example.com/examples/file.xyz",
       "created": "2000-01-01T00:00:00Z",
       "updated": "2020-01-01T00:00:00Z",
-      "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "linz:encoding": "utf-8",
+      "linz:language": "en_NZ"
     }
   },
   "linz:geospatial_type": "polygon"

--- a/extensions/linz/examples/item.json
+++ b/extensions/linz/examples/item.json
@@ -39,7 +39,7 @@
       "updated": "2020-01-01T00:00:00Z",
       "file:checksum": "1220e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "linz:encoding": "utf-8",
-      "linz:language": "en_NZ"
+      "linz:language": "en-NZ"
     }
   },
   "linz:geospatial_type": "polygon"

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -98,6 +98,12 @@
                 "format": "date-time",
                 "pattern": "(\\+00:00|Z)$"
               },
+              "linz:encoding": {
+                "type": "string"
+              },
+              "linz:language": {
+                "type": "string"
+              },
               "updated": {
                 "title": "Last update time",
                 "type": "string",

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -99,10 +99,12 @@
                 "pattern": "(\\+00:00|Z)$"
               },
               "linz:encoding": {
-                "type": "string"
+                "type": "string",
+                "enum": ["utf-8"]
               },
               "linz:language": {
-                "type": "string"
+                "type": "string",
+                "pattern": "^[a-z]{2}-[A-Z]{2}$"
               },
               "updated": {
                 "title": "Last update time",

--- a/extensions/linz/tests/linz_collection.test.js
+++ b/extensions/linz/tests/linz_collection.test.js
@@ -338,4 +338,38 @@ o.spec('LINZ collection', () => {
       JSON.stringify(validate.errors),
     );
   });
+
+  o("Example with incorrect 'linz:language' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['assets']['example']['linz:language'] = 1;
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.dataPath === ".assets['example']['linz:language']" && error.message === 'should be string',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+
+  o("Example with incorrect 'linz:encoding' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['assets']['example']['linz:encoding'] = 1;
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.dataPath === ".assets['example']['linz:encoding']" && error.message === 'should be string',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });


### PR DESCRIPTION
Leaving as draft until we have discussed the options raised on the ticket... 

```
Why those specific standards?

    In my experience IETF language codes are much more common than ISO 639-2.
    IETF language codes allow (but does not mandate) specifying languages as written within different locales, so you can use "en" for English or "en_NZ" for New Zealand English. It doesn't look like ISO 639-2 supports this.
    UTF-8 is much more common than ISO/IEC 10646:2020.
    ISO/IEC 10646:2020 has a full seven encoding schemes.
    ISO standards are expensive and not publicly available.
    "JSON exchange in an open ecosystem must be encoded in UTF-8."
```