### PR TITLE
feat: Fix strict ajv warnings

### DIFF
--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -9,6 +9,7 @@
     },
     {
       "if": {
+        "type": "object",
         "properties": {
           "type": {
             "const": "Feature"
@@ -25,6 +26,7 @@
               "properties": {
                 "allOf": [
                   {
+                    "type": "object",
                     "required": ["aerial-photo:run", "aerial-photo:sequence_number"]
                   },
                   {
@@ -44,6 +46,7 @@
       },
       "else": {
         "if": {
+          "type": "object",
           "properties": {
             "type": {
               "const": "Collection"

--- a/extensions/film/schema.json
+++ b/extensions/film/schema.json
@@ -9,6 +9,7 @@
     },
     {
       "if": {
+        "type": "object",
         "properties": {
           "type": {
             "const": "Feature"
@@ -25,6 +26,7 @@
               "properties": {
                 "allOf": [
                   {
+                    "type": "object",
                     "required": ["film:id", "film:negative_sequence"]
                   },
                   {
@@ -44,6 +46,7 @@
       },
       "else": {
         "if": {
+          "type": "object",
           "properties": {
             "type": {
               "const": "Collection"

--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -12,6 +12,7 @@
     },
     {
       "if": {
+        "type": "object",
         "properties": {
           "type": {
             "const": "Feature"
@@ -34,6 +35,7 @@
                 "type": "object",
                 "$comment": "Require fields here for Item Asset Properties.",
                 "additionalProperties": {
+                  "type": "object",
                   "required": ["eo:bands"]
                 }
               }
@@ -43,6 +45,7 @@
       },
       "else": {
         "if": {
+          "type": "object",
           "properties": {
             "type": {
               "const": "Collection"
@@ -121,9 +124,12 @@
         "providers": {
           "allOf": [
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "licensor"
                     }
@@ -132,9 +138,12 @@
               }
             },
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "producer"
                     }
@@ -143,9 +152,12 @@
               }
             },
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "processor"
                     }
@@ -154,9 +166,12 @@
               }
             },
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "host"
                     }
@@ -167,6 +182,7 @@
           ]
         },
         "summaries": {
+          "type": "object",
           "required": ["platform", "mission", "proj:epsg"],
           "properties": {
             "platform": {

--- a/extensions/linz/schema.json
+++ b/extensions/linz/schema.json
@@ -22,6 +22,7 @@
     {
       "$comment": "Type-specific schemas",
       "if": {
+        "type": "object",
         "properties": {
           "type": {
             "const": "Collection"
@@ -88,6 +89,7 @@
       },
       "else": {
         "if": {
+          "type": "object",
           "properties": {
             "type": {
               "const": "Feature"
@@ -940,9 +942,11 @@
           }
         },
         "linz:asset_summaries": {
+          "type": "object",
           "required": ["created", "updated"],
           "properties": {
             "created": {
+              "type": "object",
               "required": ["minimum", "maximum"],
               "properties": {
                 "minimum": {
@@ -956,6 +960,7 @@
               }
             },
             "updated": {
+              "type": "object",
               "required": ["minimum", "maximum"],
               "properties": {
                 "minimum": {
@@ -984,8 +989,10 @@
           "allOf": [
             {
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "manager"
                     }
@@ -995,8 +1002,10 @@
             },
             {
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "custodian"
                     }
@@ -1045,9 +1054,12 @@
         "providers": {
           "allOf": [
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "licensor"
                     }
@@ -1056,9 +1068,12 @@
               }
             },
             {
+              "type": "array",
               "contains": {
+                "type": "object",
                 "properties": {
                   "roles": {
+                    "type": "array",
                     "contains": {
                       "const": "producer"
                     }

--- a/extensions/template/schema.json
+++ b/extensions/template/schema.json
@@ -20,6 +20,7 @@
             "properties": {
               "allOf": [
                 {
+                  "type": "object",
                   "$comment": "Require fields here for Item Properties.",
                   "required": ["template:new_field"]
                 },
@@ -142,9 +143,9 @@
     "require_any_field": {
       "$comment": "Please list all fields here so that we can force the existence of one of them in other parts of the schemas.",
       "anyOf": [
-        { "required": ["template:new_field"] },
-        { "required": ["template:xyz"] },
-        { "required": ["template:another_one"] }
+        { "type": "object", "required": ["template:new_field"] },
+        { "type": "object", "required": ["template:xyz"] },
+        { "type": "object", "required": ["template:another_one"] }
       ]
     },
     "fields": {


### PR DESCRIPTION
See <https://ajv.js.org/strict-mode.html>.

These are the last warnings in our schemas - see `npx ospec 2> >(grep --fixed-strings --invert-match --regex='stac-extensions.github.io' --regex=schemas.stacspec.org >&2)` (this command basically removes the warnings for stac-extensions.github.io and schemas.stacspec.org from standard error, showing only the LINZ-related ajv warnings).