### PR TITLE
fix: remove eo and file extensions from examples

### DIFF
--- a/extensions/aerial-photo/examples/item.json
+++ b/extensions/aerial-photo/examples/item.json
@@ -19,14 +19,7 @@
   "assets": {
     "visual": {
       "href": "./72360.tiff",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130",
-      "eo:bands": [
-        {
-          "name": "gray",
-          "common_name": "pan"
-        }
-      ]
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   }
 }

--- a/extensions/camera/examples/item.json
+++ b/extensions/camera/examples/item.json
@@ -16,14 +16,7 @@
   "assets": {
     "visual": {
       "href": "./72360.tiff",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130",
-      "eo:bands": [
-        {
-          "name": "gray",
-          "common_name": "pan"
-        }
-      ]
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   }
 }

--- a/extensions/film/examples/item.json
+++ b/extensions/film/examples/item.json
@@ -18,14 +18,7 @@
   "assets": {
     "visual": {
       "href": "./72360.tiff",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130",
-      "eo:bands": [
-        {
-          "name": "gray",
-          "common_name": "pan"
-        }
-      ]
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   }
 }

--- a/extensions/scanning/examples/item.json
+++ b/extensions/scanning/examples/item.json
@@ -16,14 +16,7 @@
   "assets": {
     "visual": {
       "href": "./72360.tiff",
-      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-      "file:checksum": "1220b7deb18ad9dc6f3f94df60c26dd235a019946b8b6b7d1a36f100a8f9f1889130",
-      "eo:bands": [
-        {
-          "name": "gray",
-          "common_name": "pan"
-        }
-      ]
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized"
     }
   }
 }


### PR DESCRIPTION
These fields shouldn't be there as the extensions are not included in the stac_extensions