### PR TITLE
feat: add summaries to historical imagery related extensions

### DIFF
--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -42,12 +42,15 @@
       "type": "object",
       "allOf": [
         {
-          "required": ["type"],
+          "required": ["type", "summaries"],
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
+        },
+        {
+          "$ref": "#/definitions/fields"
         },
         {
           "$ref": "#/definitions/stac_extensions"
@@ -90,6 +93,68 @@
         "aerial-photo:anomalies": {
           "title": "Image anomalies",
           "type": "string"
+        },
+        "summaries": {
+          "type": "object",
+          "required": ["aerial-photo:run", "aerial-photo:sequence_number"],
+          "properties": {
+            "aerial-photo:run": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "aerial-photo:sequence_number": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Lowest sequence number",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Highest sequence number",
+                  "type": "integer"
+                }
+              }
+            },
+            "aerial-photo:altitude": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Lowest altitude",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Highest altitude",
+                  "type": "integer"
+                }
+              }
+            },
+            "aerial-photo:scale": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Minimum scale",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Maximum scale",
+                  "type": "integer"
+                }
+              }
+            },
+            "aerial-photo:anomalies": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            }
+          }
         }
       },
       "patternProperties": {

--- a/extensions/aerial-photo/tests/aerial_photo_collection.test.js
+++ b/extensions/aerial-photo/tests/aerial_photo_collection.test.js
@@ -29,4 +29,39 @@ o.spec('Aerial Photo Extension Collection', () => {
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
+  o("Summaries with no 'aerial-photo:run' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['aerial-photo:run'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) =>
+          error.instancePath === '/summaries' && error.message === "must have required property 'aerial-photo:run'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+  o("Summaries with no 'aerial-photo:sequence_number' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['aerial-photo:sequence_number'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) =>
+          error.instancePath === '/summaries' &&
+          error.message === "must have required property 'aerial-photo:sequence_number'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });

--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -43,6 +43,9 @@
           }
         },
         {
+          "$ref": "#/definitions/fields"
+        },
+        {
           "$ref": "#/definitions/stac_extensions"
         }
       ]
@@ -71,6 +74,39 @@
         "camera:nominal_focal_length": {
           "title": "Nominal Focal Length",
           "type": ["integer"]
+        },
+        "summaries": {
+          "type": "object",
+          "properties": {
+            "camera:sequence_number": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Lowest sequence number",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Highest sequence number",
+                  "type": "integer"
+                }
+              }
+            },
+            "camera:nominal_focal_length": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Lowest nominal focal length",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Highest nominal focal length",
+                  "type": "integer"
+                }
+              }
+            }
+          }
         }
       },
       "patternProperties": {

--- a/extensions/film/examples/collection.json
+++ b/extensions/film/examples/collection.json
@@ -33,7 +33,7 @@
     "mission": ["399"],
     "film:id": ["464", "465", "466", "470", "476", "486", "577", "579", "580", "728", "731", "732"],
     "film:negative_sequence": {
-      "mimimum": 1,
+      "minimum": 1,
       "maximum": 184
     },
     "film:physical_condition": ["Film scratched", "NOT 10/03/1949", "NOT 16/04/1947"],

--- a/extensions/film/schema.json
+++ b/extensions/film/schema.json
@@ -42,12 +42,15 @@
       "type": "object",
       "allOf": [
         {
-          "required": ["type"],
+          "required": ["type", "summaries"],
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
+        },
+        {
+          "$ref": "#/definitions/fields"
         },
         {
           "$ref": "#/definitions/stac_extensions"
@@ -86,6 +89,47 @@
         "film:physical_size": {
           "title": "Physical Size Format",
           "type": "string"
+        },
+        "summaries": {
+          "type": "object",
+          "required": ["film:id", "film:negative_sequence"],
+          "properties": {
+            "film:id": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "film:negative_sequence": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Lowest negative sequence number",
+                  "type": "integer"
+                },
+                "maximum": {
+                  "title": "Highest negative sequence number",
+                  "type": "integer"
+                }
+              }
+            },
+            "film:physical_condition": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "film:physical_size": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            }
+          }
         }
       },
       "patternProperties": {

--- a/extensions/film/tests/film_collection.test.js
+++ b/extensions/film/tests/film_collection.test.js
@@ -29,4 +29,38 @@ o.spec('Film Extension Collection', () => {
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
+  o("Summaries with no 'film:id' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['film:id'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'film:id'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+  o("Summaries with no 'film:negative_sequence' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['film:negative_sequence'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) =>
+          error.instancePath === '/summaries' &&
+          error.message === "must have required property 'film:negative_sequence'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });

--- a/extensions/historical-imagery/examples/collection.json
+++ b/extensions/historical-imagery/examples/collection.json
@@ -90,10 +90,7 @@
       "minimum": "2018-06-30T12:00:00Z",
       "maximum": "2019-12-31T11:00:00Z"
     },
-    "proj:epsg": {
-      "minimum": 2193,
-      "maximum": 2193
-    },
+    "proj:epsg": [2193],
     "aerial-photo:altitude": {
       "minimum": 10000,
       "maximum": 11000
@@ -115,7 +112,7 @@
       "maximum": 508
     },
     "film:negative_sequence": {
-      "mimimum": 1,
+      "minimum": 1,
       "maximum": 184
     }
   },

--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -38,7 +38,7 @@
       "allOf": [
         {
           "type": "object",
-          "required": ["type", "title", "providers"],
+          "required": ["type", "title", "providers", "summaries"],
           "properties": {
             "type": {
               "const": "Collection"
@@ -46,7 +46,7 @@
           }
         },
         {
-          "$ref": "#/definitions/fields_collection"
+          "$ref": "#/definitions/fields"
         },
         {
           "$ref": "#/definitions/stac_extensions"
@@ -106,7 +106,7 @@
         }
       }
     },
-    "fields_collection": {
+    "fields": {
       "type": "object",
       "$comment": "Remove licensor and producer when validation against linz STAC extension is included.",
       "properties": {
@@ -157,6 +157,39 @@
               }
             }
           ]
+        },
+        "summaries": {
+          "required": ["platform", "mission", "proj:epsg"],
+          "properties": {
+            "platform": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "mission": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "instruments": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minItems": 1
+              }
+            },
+            "proj:epsg": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "minItems": 1
+              }
+            }
+          }
         }
       }
     }

--- a/extensions/historical-imagery/tests/historical-imagery_collection.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_collection.test.js
@@ -80,4 +80,52 @@ o.spec('Historical Imagery Extension Collection', () => {
       ).equals(true)(JSON.stringify(validate.errors));
     }
   });
+  o("Summaries with no 'platform' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries.platform;
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'platform'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+  o("Summaries with no 'mission' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries.mission;
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'mission'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+  o("Summaries with no 'proj:epsg' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['proj:epsg'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'proj:epsg'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });

--- a/extensions/scanning/schema.json
+++ b/extensions/scanning/schema.json
@@ -43,6 +43,9 @@
           }
         },
         {
+          "$ref": "#/definitions/fields"
+        },
+        {
           "$ref": "#/definitions/stac_extensions"
         }
       ]
@@ -73,6 +76,36 @@
           "type": "string",
           "format": "date-time",
           "pattern": "(\\+00:00|Z)$"
+        },
+        "summaries": {
+          "type": "object",
+          "properties": {
+            "scan:is_original": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "scan:scanned": {
+              "type": "object",
+              "required": ["minimum", "maximum"],
+              "properties": {
+                "minimum": {
+                  "title": "Earliest date",
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "(\\+00:00|Z)$"
+                },
+                "maximum": {
+                  "title": "Most recent date",
+                  "type": "string",
+                  "format": "date-time",
+                  "pattern": "(\\+00:00|Z)$"
+                }
+              }
+            }
+          }
         }
       },
       "patternProperties": {


### PR DESCRIPTION
Extensions updated to include summary requirements:

- historical imagery
-  aerial-photo
-  camera
-  scanning 
- film extensions

nb: eo:bands cannot be added to the historical imagery schema as it would be an asset summary (please correct me if I'm wrong here).