### PR TITLE
docs: add missing extension to linz extension README

### DIFF
--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -121,6 +121,7 @@ This extension includes these other extensions:
 - [projection](https://github.com/stac-extensions/projection)
 - [quality](../quality)
 - [version](https://github.com/stac-extensions/version)
+- [processing](https://github.com/stac-extensions/processing)
 
 ## Contributing
 

--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -118,10 +118,10 @@ These fields apply to assets within both items and collections.
 
 This extension includes these other extensions:
 
+- [processing](https://github.com/stac-extensions/processing)
 - [projection](https://github.com/stac-extensions/projection)
 - [quality](../quality)
 - [version](https://github.com/stac-extensions/version)
-- [processing](https://github.com/stac-extensions/processing)
 
 ## Contributing
 


### PR DESCRIPTION
Noticed processing extension was missing from the list of other extensions used.