### PR TITLE
Remove redundant paths in metadata docs

### DIFF
--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -121,6 +121,7 @@ This extension includes these other extensions:
 - [projection](https://github.com/stac-extensions/projection)
 - [quality](../quality)
 - [version](https://github.com/stac-extensions/version)
+- [processing](https://github.com/stac-extensions/processing)
 
 ## Contributing
 

--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -118,10 +118,10 @@ These fields apply to assets within both items and collections.
 
 This extension includes these other extensions:
 
+- [processing](https://github.com/stac-extensions/processing)
 - [projection](https://github.com/stac-extensions/projection)
 - [quality](../quality)
 - [version](https://github.com/stac-extensions/version)
-- [processing](https://github.com/stac-extensions/processing)
 
 ## Contributing
 

--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -107,12 +107,12 @@ This expands on the [provider object in the STAC spec](https://github.com/radian
 
 These fields apply to assets within both items and collections.
 
-| Field Name              | Type   | Description                                                                                                                     |
-| ----------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| assets/\*/created       | string | **REQUIRED**. Creation date and time of the asset, in UTC.                                                                      |
-| assets/\*/updated       | string | **REQUIRED**. Date and time the asset was last updated, in UTC.                                                                 |
-| assets/\*/file:checksum | string | **REQUIRED**. See [reference](https://github.com/stac-extensions/file/blob/v2.0.0/README.md#checksums).                         |
-| linz:language           | string | **REQUIRED**. [RFC 5646 language tag](https://datatracker.ietf.org/doc/html/rfc5646), for example `en-NZ` (New Zealand English) |
+| Field Name    | Type   | Description                                                                                                                     |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| created       | string | **REQUIRED**. Creation date and time of the asset, in UTC.                                                                      |
+| updated       | string | **REQUIRED**. Date and time the asset was last updated, in UTC.                                                                 |
+| file:checksum | string | **REQUIRED**. See [reference](https://github.com/stac-extensions/file/blob/v2.0.0/README.md#checksums).                         |
+| linz:language | string | **REQUIRED**. [RFC 5646 language tag](https://datatracker.ietf.org/doc/html/rfc5646), for example `en-NZ` (New Zealand English) |
 
 ## Extensions
 


### PR DESCRIPTION
Having `/assets/*` in the metadata path seems redundant (It's already clear from the table title that we are talking about assets). If not redundant, it's at least inconsistent with how we've documented other metadata.