### PR TITLE
docs: remove redundant metadata path info

### DIFF
--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -107,12 +107,12 @@ This expands on the [provider object in the STAC spec](https://github.com/radian
 
 These fields apply to assets within both items and collections.
 
-| Field Name              | Type   | Description                                                                                                                                                                                        |
-| ----------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| assets/\*/created       | string | **REQUIRED**. Creation date and time of the asset, in UTC.                                                                                                                                         |
-| assets/\*/updated       | string | **REQUIRED**. Date and time the asset was last updated, in UTC.                                                                                                                                    |
-| assets/\*/file:checksum | string | **REQUIRED**. See [reference](https://github.com/stac-extensions/file/blob/v2.0.0/README.md#checksums).                                                                                            |
-| linz:language           | string | Required for assets which include text when the collection is shared externally. [RFC 5646 language tag](https://datatracker.ietf.org/doc/html/rfc5646), for example `en-NZ` (New Zealand English) |
+| Field Name    | Type   | Description                                                                                                                                                                                        |
+| ------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| created       | string | **REQUIRED**. Creation date and time of the asset, in UTC.                                                                                                                                         |
+| updated       | string | **REQUIRED**. Date and time the asset was last updated, in UTC.                                                                                                                                    |
+| file:checksum | string | **REQUIRED**. See [reference](https://github.com/stac-extensions/file/blob/v2.0.0/README.md#checksums).                                                                                            |
+| linz:language | string | Required for assets which include text when the collection is shared externally. [RFC 5646 language tag](https://datatracker.ietf.org/doc/html/rfc5646), for example `en-NZ` (New Zealand English) |
 
 ## Extensions
 


### PR DESCRIPTION
Having /assets/* in the metadata path seems redundant (It's already clear from the table title that we are talking about assets). If not redundant, it's at least inconsistent with how we've documented other metadata.