### PR TITLE
fix: historical imagery should not require instruments field

### DIFF
--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -17,7 +17,7 @@
             "properties": {
               "type": "object",
               "$comment": "Require fields here for Item Properties.",
-              "required": ["platform", "instruments", "mission"]
+              "required": ["platform", "mission"]
             },
             "assets": {
               "type": "object",

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.js
@@ -30,6 +30,17 @@ o.spec('Historical Imagery Extension Item', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
+  o("Example without optional 'instruments' property should pass validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.properties['instruments'];
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
+  });
+
   o("Example without mandatory 'mission' property should fail validation", async () => {
     // given
     const example = JSON.parse(await fs.readFile(examplePath));


### PR DESCRIPTION
Fixing a mistake - the historical imagery extension should not require the 'instruments' Item field.