### PR TITLE
Use `conditional` instead of `oneOf` in extensions

### DIFF
--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -31,6 +31,12 @@
                     "$ref": "#/definitions/fields"
                   }
                 ]
+              },
+              "assets": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/fields"
+                }
               }
             }
           }

--- a/extensions/aerial-photo/schema.json
+++ b/extensions/aerial-photo/schema.json
@@ -3,59 +3,61 @@
   "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json",
   "title": "Aerial Photography Extension",
   "description": "STAC Aerial Photography Extension for STAC Items, and Collection Summaries.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "Feature"
+          }
+        }
+      },
+      "then": {
+        "$comment": "This is the schema for STAC Items.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["type", "properties", "assets"],
             "properties": {
-              "allOf": [
-                {
-                  "required": ["aerial-photo:run", "aerial-photo:sequence_number"]
-                },
-                {
-                  "$ref": "#/definitions/fields"
-                }
-              ]
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
+              "properties": {
+                "allOf": [
+                  {
+                    "required": ["aerial-photo:run", "aerial-photo:sequence_number"]
+                  },
+                  {
+                    "$ref": "#/definitions/fields"
+                  }
+                ]
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
-    },
-    {
-      "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
-      "type": "object",
-      "allOf": [
-        {
-          "required": ["type", "summaries"],
+        ]
+      },
+      "else": {
+        "if": {
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
         },
-        {
-          "$ref": "#/definitions/fields"
+        "then": {
+          "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
+          "type": "object",
+          "allOf": [
+            {
+              "required": ["type", "summaries"]
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+        "else": false
+      }
     }
   ],
   "definitions": {

--- a/extensions/aerial-photo/tests/aerial_photo_item.test.js
+++ b/extensions/aerial-photo/tests/aerial_photo_item.test.js
@@ -30,22 +30,22 @@ o.spec('Aerial Photo Extension Item', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  o("Example with an incorrect 'aerial-photo:run' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.properties['aerial-photo:run'] = 1234;
+    o("Example with an incorrect 'aerial-photo:run' field should fail validation", async () => {
+      // given
+      const example = JSON.parse(await fs.readFile(examplePath));
+      example.properties['aerial-photo:run'] = 1234;
 
-    // when
-    let valid = validate(example);
+      // when
+      let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/properties/aerial-photo:run' && error.message === 'must be string',
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+      // then
+      o(valid).equals(false);
+      o(
+        validate.errors.some(
+          (error) => error.instancePath === '/properties/aerial-photo:run' && error.message === 'must be string',
+        ),
+      ).equals(true)(JSON.stringify(validate.errors));
+    });
 
   o("Example without the mandatory 'aerial-photo:run' field should fail validation", async () => {
     // given

--- a/extensions/aerial-photo/tests/aerial_photo_item.test.js
+++ b/extensions/aerial-photo/tests/aerial_photo_item.test.js
@@ -30,22 +30,22 @@ o.spec('Aerial Photo Extension Item', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-    o("Example with an incorrect 'aerial-photo:run' field should fail validation", async () => {
-      // given
-      const example = JSON.parse(await fs.readFile(examplePath));
-      example.properties['aerial-photo:run'] = 1234;
+  o("Example with an incorrect 'aerial-photo:run' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example.properties['aerial-photo:run'] = 1234;
 
-      // when
-      let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-      // then
-      o(valid).equals(false);
-      o(
-        validate.errors.some(
-          (error) => error.instancePath === '/properties/aerial-photo:run' && error.message === 'must be string',
-        ),
-      ).equals(true)(JSON.stringify(validate.errors));
-    });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/properties/aerial-photo:run' && error.message === 'must be string',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
   o("Example without the mandatory 'aerial-photo:run' field should fail validation", async () => {
     // given

--- a/extensions/camera/schema.json
+++ b/extensions/camera/schema.json
@@ -3,52 +3,60 @@
   "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json",
   "title": "Camera Extension",
   "description": "STAC Camera Extension for STAC Items, and Collection Summaries.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "Feature"
+          }
+        }
+      },
+      "then": {
+        "$comment": "This is the schema for STAC Items.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["type", "properties", "assets"],
             "properties": {
-              "$ref": "#/definitions/fields"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
+              "properties": {
                 "$ref": "#/definitions/fields"
+              },
+              "assets": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/fields"
+                }
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
-    },
-    {
-      "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
-      "type": "object",
-      "allOf": [
-        {
-          "required": ["type"],
+        ]
+      },
+      "else": {
+        "if": {
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
         },
-        {
-          "$ref": "#/definitions/fields"
+        "then": {
+          "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
+          "type": "object",
+          "allOf": [
+            {
+              "required": ["type"]
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+        "else": false
+      }
     }
   ],
   "definitions": {

--- a/extensions/film/schema.json
+++ b/extensions/film/schema.json
@@ -3,59 +3,67 @@
   "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json",
   "title": "Film Extension",
   "description": "STAC Film Extension for STAC Items, and Collection Summaries.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "Feature"
+          }
+        }
+      },
+      "then": {
+        "$comment": "This is the schema for STAC Items.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["type", "properties", "assets"],
             "properties": {
-              "allOf": [
-                {
-                  "required": ["film:id", "film:negative_sequence"]
-                },
-                {
+              "properties": {
+                "allOf": [
+                  {
+                    "required": ["film:id", "film:negative_sequence"]
+                  },
+                  {
+                    "$ref": "#/definitions/fields"
+                  }
+                ]
+              },
+              "assets": {
+                "type": "object",
+                "additionalProperties": {
                   "$ref": "#/definitions/fields"
                 }
-              ]
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/fields"
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
-    },
-    {
-      "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
-      "type": "object",
-      "allOf": [
-        {
-          "required": ["type", "summaries"],
+        ]
+      },
+      "else": {
+        "if": {
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
         },
-        {
-          "$ref": "#/definitions/fields"
+        "then": {
+          "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
+          "type": "object",
+          "allOf": [
+            {
+              "required": ["type", "summaries"]
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+        "else": false
+      }
     }
   ],
   "definitions": {

--- a/extensions/historical-imagery/schema.json
+++ b/extensions/historical-imagery/schema.json
@@ -3,55 +3,63 @@
   "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json",
   "title": "Historical Imagery Extension",
   "description": "STAC Historical Imagery Extension for STAC Items and STAC Collections.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "$ref": "#/definitions/fields"
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "Feature"
+          }
+        }
+      },
+      "then": {
+        "$comment": "This is the schema for STAC Items.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["type", "properties", "assets"],
             "properties": {
-              "type": "object",
-              "$comment": "Require fields here for Item Properties.",
-              "required": ["platform", "mission"]
-            },
-            "assets": {
-              "type": "object",
-              "$comment": "Require fields here for Item Asset Properties.",
-              "additionalProperties": {
-                "required": ["eo:bands"]
+              "properties": {
+                "type": "object",
+                "$comment": "Require fields here for Item Properties.",
+                "required": ["platform", "mission"]
+              },
+              "assets": {
+                "type": "object",
+                "$comment": "Require fields here for Item Asset Properties.",
+                "additionalProperties": {
+                  "required": ["eo:bands"]
+                }
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
-    },
-    {
-      "$comment": "This is the schema for STAC Collections. Require fields here for Collections (top-level).",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "title", "providers", "summaries"],
+        ]
+      },
+      "else": {
+        "if": {
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
         },
-        {
-          "$ref": "#/definitions/fields"
+        "then": {
+          "$comment": "This is the schema for STAC Collections. Require fields here for Collections (top-level).",
+          "allOf": [
+            {
+              "type": "object",
+              "required": ["type", "title", "providers", "summaries"]
+            }
+          ]
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+        "else": false
+      }
     }
   ],
   "definitions": {

--- a/extensions/historical-imagery/tests/historical-imagery_collection.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_collection.test.js
@@ -26,173 +26,173 @@ o.spec('Historical Imagery Extension Collection', () => {
     const example = JSON.parse(await fs.readFile(examplePath));
 
     // when
-    let valid = validate(example);
+    const valid = validate(example);
 
     // then
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  o("Example without 'title' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.title;
+  //   o("Example without 'title' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.title;
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(validate.errors.some((error) => error.message === "must have required property 'title'")).equals(true)(
-      JSON.stringify(validate.errors),
-    );
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(validate.errors.some((error) => error.message === "must have required property 'title'")).equals(true)(
+  //       JSON.stringify(validate.errors),
+  //     );
+  //   });
 
-  o("Example without 'providers' should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.providers;
+  //   o("Example without 'providers' should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.providers;
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(validate.errors.some((error) => error.message === "must have required property 'providers'")).equals(true)(
-      JSON.stringify(validate.errors),
-    );
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(validate.errors.some((error) => error.message === "must have required property 'providers'")).equals(true)(
+  //       JSON.stringify(validate.errors),
+  //     );
+  //   });
 
-  o('Collection without required provider roles should fail validation', async () => {
-    // given
-    for (const role of ['producer', 'licensor', 'processor', 'host']) {
-      const example = JSON.parse(await fs.readFile(examplePath));
-      example.providers = example.providers.filter((provider) => !role in provider.roles);
+  //   o('Collection without required provider roles should fail validation', async () => {
+  //     // given
+  //     for (const role of ['producer', 'licensor', 'processor', 'host']) {
+  //       const example = JSON.parse(await fs.readFile(examplePath));
+  //       example.providers = example.providers.filter((provider) => !role in provider.roles);
 
-      // when
-      let valid = validate(example);
+  //       // when
+  //       let valid = validate(example);
 
-      // then
-      o(valid).equals(false);
-      o(
-        validate.errors.some(
-          (error) => error.instancePath === '/providers' && error.message === 'must contain at least 1 valid item(s)',
-        ),
-      ).equals(true)(JSON.stringify(validate.errors));
-    }
-  });
+  //       // then
+  //       o(valid).equals(false);
+  //       o(
+  //         validate.errors.some(
+  //           (error) => error.instancePath === '/providers' && error.message === 'must contain at least 1 valid item(s)',
+  //         ),
+  //       ).equals(true)(JSON.stringify(validate.errors));
+  //     }
+  //   });
 
-  o("Summaries with no 'platform' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.summaries.platform;
+  //   o("Summaries with no 'platform' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.summaries.platform;
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'platform'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'platform'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with empty 'platform' list should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.summaries.platform = [];
+  //   o("Summaries with empty 'platform' list should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     example.summaries.platform = [];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/summaries/platform' && error.message === 'must NOT have fewer than 1 items',
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/summaries/platform' && error.message === 'must NOT have fewer than 1 items',
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with no 'mission' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.summaries.mission;
+  //   o("Summaries with no 'mission' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.summaries.mission;
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'mission'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'mission'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with empty 'mission' list should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.summaries.mission = [];
+  //   o("Summaries with empty 'mission' list should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     example.summaries.mission = [];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/summaries/mission' && error.message === 'must NOT have fewer than 1 items',
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/summaries/mission' && error.message === 'must NOT have fewer than 1 items',
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with empty 'instruments' list should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.summaries.instruments = [];
+  //   o("Summaries with empty 'instruments' list should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     example.summaries.instruments = [];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) =>
-          error.instancePath === '/summaries/instruments' && error.message === 'must NOT have fewer than 1 items',
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) =>
+  //           error.instancePath === '/summaries/instruments' && error.message === 'must NOT have fewer than 1 items',
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with no 'proj:epsg' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.summaries['proj:epsg'];
+  //   o("Summaries with no 'proj:epsg' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.summaries['proj:epsg'];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'proj:epsg'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'proj:epsg'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Summaries with empty 'proj:epsg' list should pass validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    example.summaries['proj:epsg'] = [];
+  //   o("Summaries with empty 'proj:epsg' list should pass validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     example.summaries['proj:epsg'] = [];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(true);
-  });
+  //     // then
+  //     o(valid).equals(true);
+  //   });
 });

--- a/extensions/historical-imagery/tests/historical-imagery_collection.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_collection.test.js
@@ -21,6 +21,38 @@ o.spec('Historical Imagery Extension Collection', () => {
     validate = await ajv.compileAsync(data);
   });
 
+  o("Example with an invalid 'type' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['type'] = 'incorrect_example';
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(validate.errors.some((error) => error.instancePath === '' && error.message === 'boolean schema is false')).equals(
+      true,
+    )(JSON.stringify(validate.errors));
+  });
+
+  o("Example with an Item 'type' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['type'] = 'Feature';
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '' && error.message === "must have required property 'properties'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+
   o('Example should pass validation', async () => {
     // given
     const example = JSON.parse(await fs.readFile(examplePath));
@@ -32,167 +64,167 @@ o.spec('Historical Imagery Extension Collection', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  //   o("Example without 'title' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.title;
+  o("Example without 'title' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.title;
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(validate.errors.some((error) => error.message === "must have required property 'title'")).equals(true)(
-  //       JSON.stringify(validate.errors),
-  //     );
-  //   });
+    // then
+    o(valid).equals(false);
+    o(validate.errors.some((error) => error.message === "must have required property 'title'")).equals(true)(
+      JSON.stringify(validate.errors),
+    );
+  });
 
-  //   o("Example without 'providers' should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.providers;
+  o("Example without 'providers' should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.providers;
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(validate.errors.some((error) => error.message === "must have required property 'providers'")).equals(true)(
-  //       JSON.stringify(validate.errors),
-  //     );
-  //   });
+    // then
+    o(valid).equals(false);
+    o(validate.errors.some((error) => error.message === "must have required property 'providers'")).equals(true)(
+      JSON.stringify(validate.errors),
+    );
+  });
 
-  //   o('Collection without required provider roles should fail validation', async () => {
-  //     // given
-  //     for (const role of ['producer', 'licensor', 'processor', 'host']) {
-  //       const example = JSON.parse(await fs.readFile(examplePath));
-  //       example.providers = example.providers.filter((provider) => !role in provider.roles);
+  o('Collection without required provider roles should fail validation', async () => {
+    // given
+    for (const role of ['producer', 'licensor', 'processor', 'host']) {
+      const example = JSON.parse(await fs.readFile(examplePath));
+      example.providers = example.providers.filter((provider) => !role in provider.roles);
 
-  //       // when
-  //       let valid = validate(example);
+      // when
+      let valid = validate(example);
 
-  //       // then
-  //       o(valid).equals(false);
-  //       o(
-  //         validate.errors.some(
-  //           (error) => error.instancePath === '/providers' && error.message === 'must contain at least 1 valid item(s)',
-  //         ),
-  //       ).equals(true)(JSON.stringify(validate.errors));
-  //     }
-  //   });
+      // then
+      o(valid).equals(false);
+      o(
+        validate.errors.some(
+          (error) => error.instancePath === '/providers' && error.message === 'must contain at least 1 valid item(s)',
+        ),
+      ).equals(true)(JSON.stringify(validate.errors));
+    }
+  });
 
-  //   o("Summaries with no 'platform' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.summaries.platform;
+  o("Summaries with no 'platform' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries.platform;
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'platform'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'platform'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with empty 'platform' list should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     example.summaries.platform = [];
+  o("Summaries with empty 'platform' list should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example.summaries.platform = [];
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/summaries/platform' && error.message === 'must NOT have fewer than 1 items',
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries/platform' && error.message === 'must NOT have fewer than 1 items',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with no 'mission' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.summaries.mission;
+  o("Summaries with no 'mission' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries.mission;
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'mission'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'mission'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with empty 'mission' list should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     example.summaries.mission = [];
+  o("Summaries with empty 'mission' list should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example.summaries.mission = [];
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/summaries/mission' && error.message === 'must NOT have fewer than 1 items',
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries/mission' && error.message === 'must NOT have fewer than 1 items',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with empty 'instruments' list should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     example.summaries.instruments = [];
+  o("Summaries with empty 'instruments' list should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example.summaries.instruments = [];
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) =>
-  //           error.instancePath === '/summaries/instruments' && error.message === 'must NOT have fewer than 1 items',
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) =>
+          error.instancePath === '/summaries/instruments' && error.message === 'must NOT have fewer than 1 items',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with no 'proj:epsg' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.summaries['proj:epsg'];
+  o("Summaries with no 'proj:epsg' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.summaries['proj:epsg'];
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/summaries' && error.message === "must have required property 'proj:epsg'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/summaries' && error.message === "must have required property 'proj:epsg'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Summaries with empty 'proj:epsg' list should pass validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     example.summaries['proj:epsg'] = [];
+  o("Summaries with empty 'proj:epsg' list should pass validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example.summaries['proj:epsg'] = [];
 
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(true);
-  //   });
+    // then
+    o(valid).equals(true);
+  });
 });

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.js
@@ -30,64 +30,96 @@ o.spec('Historical Imagery Extension Item', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  //   o("Example without optional 'instruments' property should pass validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.properties['instruments'];
-  //     // when
-  //     let valid = validate(example);
+  o("Example with an invalid 'type' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['type'] = 'incorrect_example';
 
-  //     // then
-  //     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
-  //   });
+    // when
+    let valid = validate(example);
 
-  //   o("Example without mandatory 'mission' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.properties['mission'];
-  //     // when
-  //     let valid = validate(example);
+    // then
+    o(valid).equals(false);
+    o(validate.errors.some((error) => error.instancePath === '' && error.message === 'boolean schema is false')).equals(
+      true,
+    )(JSON.stringify(validate.errors));
+  });
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/properties' && error.message === "must have required property 'mission'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+  o("Example with a Collection 'type' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['type'] = 'Collection';
 
-  //   o("Example without mandatory 'platform' property should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.properties['platform'];
-  //     // when
-  //     let valid = validate(example);
+    // when
+    let valid = validate(example);
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) => error.instancePath === '/properties' && error.message === "must have required property 'platform'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '' && error.message === "must have required property 'title'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 
-  //   o("Example without the mandatory 'eo:bands' field should fail validation", async () => {
-  //     // given
-  //     const example = JSON.parse(await fs.readFile(examplePath));
-  //     delete example.assets['visual']['eo:bands'];
+  o("Example without optional 'instruments' property should pass validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.properties['instruments'];
+    // when
+    let valid = validate(example);
 
-  //     // when
-  //     let valid = validate(example);
+    // then
+    o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
+  });
 
-  //     // then
-  //     o(valid).equals(false);
-  //     o(
-  //       validate.errors.some(
-  //         (error) =>
-  //           error.instancePath === '/assets/visual' && error.message === "must have required property 'eo:bands'",
-  //       ),
-  //     ).equals(true)(JSON.stringify(validate.errors));
-  //   });
+  o("Example without mandatory 'mission' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.properties['mission'];
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/properties' && error.message === "must have required property 'mission'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+
+  o("Example without mandatory 'platform' property should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.properties['platform'];
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/properties' && error.message === "must have required property 'platform'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
+
+  o("Example without the mandatory 'eo:bands' field should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    delete example.assets['visual']['eo:bands'];
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) =>
+          error.instancePath === '/assets/visual' && error.message === "must have required property 'eo:bands'",
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.js
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.js
@@ -30,64 +30,64 @@ o.spec('Historical Imagery Extension Item', () => {
     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
   });
 
-  o("Example without optional 'instruments' property should pass validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.properties['instruments'];
-    // when
-    let valid = validate(example);
+  //   o("Example without optional 'instruments' property should pass validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.properties['instruments'];
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
-  });
+  //     // then
+  //     o(valid).equals(true)(JSON.stringify(validate.errors, null, 2));
+  //   });
 
-  o("Example without mandatory 'mission' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.properties['mission'];
-    // when
-    let valid = validate(example);
+  //   o("Example without mandatory 'mission' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.properties['mission'];
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/properties' && error.message === "must have required property 'mission'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/properties' && error.message === "must have required property 'mission'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Example without mandatory 'platform' property should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.properties['platform'];
-    // when
-    let valid = validate(example);
+  //   o("Example without mandatory 'platform' property should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.properties['platform'];
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) => error.instancePath === '/properties' && error.message === "must have required property 'platform'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) => error.instancePath === '/properties' && error.message === "must have required property 'platform'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 
-  o("Example without the mandatory 'eo:bands' field should fail validation", async () => {
-    // given
-    const example = JSON.parse(await fs.readFile(examplePath));
-    delete example.assets['visual']['eo:bands'];
+  //   o("Example without the mandatory 'eo:bands' field should fail validation", async () => {
+  //     // given
+  //     const example = JSON.parse(await fs.readFile(examplePath));
+  //     delete example.assets['visual']['eo:bands'];
 
-    // when
-    let valid = validate(example);
+  //     // when
+  //     let valid = validate(example);
 
-    // then
-    o(valid).equals(false);
-    o(
-      validate.errors.some(
-        (error) =>
-          error.instancePath === '/assets/visual' && error.message === "must have required property 'eo:bands'",
-      ),
-    ).equals(true)(JSON.stringify(validate.errors));
-  });
+  //     // then
+  //     o(valid).equals(false);
+  //     o(
+  //       validate.errors.some(
+  //         (error) =>
+  //           error.instancePath === '/assets/visual' && error.message === "must have required property 'eo:bands'",
+  //       ),
+  //     ).equals(true)(JSON.stringify(validate.errors));
+  //   });
 });

--- a/extensions/linz/tests/linz_item.test.js
+++ b/extensions/linz/tests/linz_item.test.js
@@ -95,4 +95,21 @@ o.spec('LINZ item', () => {
     // then
     o(valid).equals(true);
   });
+
+  o("Example with an incorrect 'created' asset field type should fail validation", async () => {
+    // given
+    const example = JSON.parse(await fs.readFile(examplePath));
+    example['assets']['example']['created'] = 1234;
+
+    // when
+    let valid = validate(example);
+
+    // then
+    o(valid).equals(false);
+    o(
+      validate.errors.some(
+        (error) => error.instancePath === '/assets/example/created' && error.message === 'must be string',
+      ),
+    ).equals(true)(JSON.stringify(validate.errors));
+  });
 });

--- a/extensions/scanning/schema.json
+++ b/extensions/scanning/schema.json
@@ -3,52 +3,60 @@
   "$id": "https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json",
   "title": "Scanning Extension",
   "description": "STAC Scanning Extension for STAC Items, and Collection Summaries.",
-  "oneOf": [
+  "allOf": [
     {
-      "$comment": "This is the schema for STAC Items.",
-      "allOf": [
-        {
-          "type": "object",
-          "required": ["type", "properties", "assets"],
-          "properties": {
-            "type": {
-              "const": "Feature"
-            },
+      "$ref": "#/definitions/stac_extensions"
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "Feature"
+          }
+        }
+      },
+      "then": {
+        "$comment": "This is the schema for STAC Items.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["type", "properties", "assets"],
             "properties": {
-              "$ref": "#/definitions/fields"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
+              "properties": {
                 "$ref": "#/definitions/fields"
+              },
+              "assets": {
+                "type": "object",
+                "additionalProperties": {
+                  "$ref": "#/definitions/fields"
+                }
               }
             }
           }
-        },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
-    },
-    {
-      "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
-      "type": "object",
-      "allOf": [
-        {
-          "required": ["type"],
+        ]
+      },
+      "else": {
+        "if": {
           "properties": {
             "type": {
               "const": "Collection"
             }
           }
         },
-        {
-          "$ref": "#/definitions/fields"
+        "then": {
+          "$comment": "This is the schema for STAC Collections. This extension requires this for Collection summaries.",
+          "type": "object",
+          "allOf": [
+            {
+              "required": ["type"]
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
         },
-        {
-          "$ref": "#/definitions/stac_extensions"
-        }
-      ]
+        "else": false
+      }
     }
   ],
   "definitions": {


### PR DESCRIPTION
[https://linzgovt.atlassian.net/browse/TDE-239](https://linzgovt.atlassian.net/browse/TDE-239)

Align the following STAC extensions with the linz schema changes made in #177 

- aerial-photo
- camera
- film
- historical-imagery
- scanning

by using `conditional` instead of `oneOf`.

This allows us to get more information from validators that don't provide nested errors on a schema match fail.