### PR TITLE
fix: broken links on readme web pages and link consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To create a release:
 ## Adding a new extension
 
 Be sure to add a schemaMap entry to the
-[validate.sh](validate.sh) file with your json-schema
+[validate.sh](https://github.com/linz/stac/blob/master/validate.sh) file with your json-schema
 `$id` url followed by the path to the json-schema locally. This will allow
 `yarn test` to use a local json-schema file rather than retrieving a possibly yet
 un-published json-schema.

--- a/extensions/aerial-photo/README.md
+++ b/extensions/aerial-photo/README.md
@@ -9,6 +9,13 @@
 - **Scope**: Item, Collection
 - **Extension Classification**: Work In Progress (Before proposal)
 
+- Examples:
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/examples/item.json): Shows the basic usage of the extension
+    in a STAC Item
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo/schema.json)
+
 ## Item Properties or Asset Fields
 
 | Field Name                   | Type    | Description                                                                                                   |

--- a/extensions/camera/README.md
+++ b/extensions/camera/README.md
@@ -10,6 +10,13 @@ change**
 - **Scope**: Item, Collection
 - **Extension Classification**: Work In Progress (Before proposal)
 
+- Examples:
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/camera/examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/camera/examples/item.json): Shows the basic usage of the extension
+    in a STAC Item
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/camera/schema.json)
+
 ## Item Properties or Asset Fields
 
 | Field Name                  | Type    | Description                                                                                                                      |

--- a/extensions/film/README.md
+++ b/extensions/film/README.md
@@ -9,6 +9,13 @@
 - **Scope**: Item, Collection
 - **Extension Classification**: Work In Progress (Before proposal)
 
+- Examples:
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/film/examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/film/examples/item.json): Shows the basic usage of the extension
+    in a STAC Item
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/film/schema.json)
+
 ## Item Properties or Asset Fields
 
 | Field Name              | Type    | Description                                                           |

--- a/extensions/historical-imagery/README.md
+++ b/extensions/historical-imagery/README.md
@@ -75,7 +75,7 @@ For more details see
 | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------- |
 | [eo:bands](https://github.com/stac-extensions/eo/blob/v1.0.0/README.md#eobands) | \[[Band Object](https://github.com/stac-extensions/eo/blob/v1.0.0/README.md#band-object)] | **REQUIRED**. The eo:bands array is used to describe the available spectral bands in an Asset. | photo_type or image file metadata |
 
-#### [Aerial Photography Extension](../aerial-photo)
+#### [Aerial Photography Extension](https://stac.linz.govt.nz/_STAC_VERSION_/aerial-photo)
 
 | Field Name                   | Type    | Description                                                                                                   | Internal Field Name |
 | ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------- | ------------------- |
@@ -85,14 +85,14 @@ For more details see
 | aerial-photo:sequence_number | integer | **REQUIRED**. Sequential order of photos taken during a run.                                                  | photo_no            |
 | aerial-photo:anomalies       | string  | Comments about unusual things noticed in the image.                                                           | image_anomalies     |
 
-#### [Camera Extension](../camera)
+#### [Camera Extension](https://stac.linz.govt.nz/_STAC_VERSION_/camera)
 
 | Field Name                  | Type    | Description                                                                                                                      | Internal Field Name  |
 | --------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | camera:sequence_number      | integer | Also referred to as veder; the sequential order of photos taken by an individual camera.                                         | camera_sequence_no   |
 | camera:nominal_focal_length | integer | Distance in mm from the camera lens centre to the film in the camera at which the image will have the least possible distortion. | nominal_focal_length |
 
-#### [Film Extension](../film)
+#### [Film Extension](https://stac.linz.govt.nz/_STAC_VERSION_/film)
 
 | Field Name              | Type    | Description                                                                                      | Internal Field Name     |
 | ----------------------- | ------- | ------------------------------------------------------------------------------------------------ | ----------------------- |
@@ -101,7 +101,7 @@ For more details see
 | film:physical_condition | string  | Comments field about unusual film condition.                                                     | physical_film_condition |
 | film:physical_size      | string  | Physical size of the negatives on a roll of film.                                                | format                  |
 
-#### [Scanning Extension](../scanning)
+#### [Scanning Extension](https://stac.linz.govt.nz/_STAC_VERSION_/scanning)
 
 | Field Name       | Type    | Description                                                                                                                                                                                                                                                            | Internal Field Name |
 | ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |

--- a/extensions/historical-imagery/README.md
+++ b/extensions/historical-imagery/README.md
@@ -23,11 +23,11 @@ For more details see
 [The Crown Aerial Film Archive historical imagery scanning project](https://www.linz.govt.nz/about-linz/what-were-doing/projects/crown-aerial-film-archive-historical-imagery-scanning-project).
 
 - Examples:
-  - [Collection example](examples/collection.json): Shows the basic usage of the
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/examples/collection.json): Shows the basic usage of the
     extension in a STAC Collection
-  - [Item example](examples/item.json): Shows the basic usage of the extension
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/examples/item.json): Shows the basic usage of the extension
     in a STAC Item
-- [JSON Schema](./schema.json)
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/historical-imagery/schema.json)
 
 ## STAC Collections
 

--- a/extensions/linz/README.md
+++ b/extensions/linz/README.md
@@ -15,12 +15,12 @@ This is LINZ top level
 extension which adds constraints to default STAC schema fields.
 
 - Examples:
-  - [Collection example](examples/collection.json): Shows the basic usage of the
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/linz/examples/collection.json): Shows the basic usage of the
     extension in a STAC Collection
-  - [Item example](examples/item.json): Shows the basic usage of the extension
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/linz/examples/item.json): Shows the basic usage of the extension
     in a STAC Item
-- [JSON Schema](./schema.json)
-- [Changelog](./CHANGELOG.md)
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/linz/schema.json)
+- [Changelog](https://stac.linz.govt.nz/_STAC_VERSION_/linz/CHANGELOG.md)
 
 ## Item Fields
 
@@ -122,7 +122,7 @@ This extension includes these other extensions:
 
 - [processing](https://github.com/stac-extensions/processing)
 - [projection](https://github.com/stac-extensions/projection)
-- [quality](../quality)
+- [quality](https://stac.linz.govt.nz/_STAC_VERSION_/quality)
 - [version](https://github.com/stac-extensions/version)
 
 ## Contributing

--- a/extensions/quality/README.md
+++ b/extensions/quality/README.md
@@ -14,6 +14,11 @@ Quality metadata is considered to be data that indicates the geospatial quality 
 
 This extension applies to STAC Collections, as quality and accuracy is most often bound to the Collection level and therefore shared across all items. It is recommended adding these fields to the corresponding the STAC Collection for geospatial datasets.
 
+- Examples:
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/quality/examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/quality/schema.json)
+
 ## Collection Fields
 
 | Field Name                       | Type   | Description                                                                                                  |

--- a/extensions/scanning/README.md
+++ b/extensions/scanning/README.md
@@ -10,6 +10,13 @@ change**
 - **Scope**: Item, Collection
 - **Extension Classification**: Work In Progress (Before proposal)
 
+- Examples:
+  - [Collection example](https://stac.linz.govt.nz/_STAC_VERSION_/scanning/examples/collection.json): Shows the basic usage of the
+    extension in a STAC Collection
+  - [Item example](https://stac.linz.govt.nz/_STAC_VERSION_/scanning/examples/item.json): Shows the basic usage of the extension
+    in a STAC Item
+- [JSON Schema](https://stac.linz.govt.nz/_STAC_VERSION_/scanning/schema.json)
+
 ## Item Properties or Asset Fields
 
 | Field Name       | Type    | Description                                                                                                                                                                                                                                                            |


### PR DESCRIPTION

When a new release is pushed, web pages are created from the gh-pages branch, and relative links break when hosted on stac.linz.govt.nz.
This change means that the links will work when hosted on stac.linz.govt.nz.
Example and schema links have been added to all readme files so they are consistent.
