### PR TITLE
feat(historical-imagery): add quality:description to collection

### DIFF
--- a/extensions/historical-imagery/examples/collection.json
+++ b/extensions/historical-imagery/examples/collection.json
@@ -30,6 +30,7 @@
   "linz:security_classification": "unclassified",
   "linz:lifecycle": "completed",
   "linz:history": "LINZ and its predecessors, Lands & Survey and Department of Survey and Land Information (DOSLI), commissioned aerial photography for the Crown between 1936 and 2008.\nOne of the predominant uses of the aerial photography at the time was the photogrammetric mapping of New Zealand, initially at 1inch to 1mile followed by the NZMS 260 and Topo50 map series at 1:50,000.\nThese photographs were scanned through the Crown Aerial Film Archive scanning project.",
+  "quality:description": "The spatial extents provided are only an approximate coverage for the ungeoreferenced aerial photographs.",
   "linz:providers": [
     {
       "name": "Toitū Te Whenua LINZ",


### PR DESCRIPTION
`quality:description` added to the historical imagery collection.json example. 

the topo engineering team still has some development work to do on validating the collection.json objects so the decision was made not to require this field in the json schema just yet.