### PR TITLE
fix: Use specific action versions

### DIFF
--- a/.github/workflows/fields.yaml
+++ b/.github/workflows/fields.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
       - name: build fields

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
         run: echo "::set-output name=tag::${GITHUB_REF##*/}"
 
       - name: Deploy JSON Schema for version ${{ env.GITHUB_REF }}
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: extensions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
   build-nix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.0.2
       - uses: cachix/install-nix-action@v16
       - uses: cachix/cachix-action@v10
         with:


### PR DESCRIPTION
Avoids quietly using whichever version is the latest starting with the specified version number, which could break at any time.