### PR TITLE
fix: actually check formatting rather than fixing it silently

### DIFF
--- a/extensions/aerial-photo/tests/aerial_photo_collection.test.mjs
+++ b/extensions/aerial-photo/tests/aerial_photo_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/aerial-photo/tests/aerial_photo_item.test.mjs
+++ b/extensions/aerial-photo/tests/aerial_photo_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/camera/tests/camera_collection.test.mjs
+++ b/extensions/camera/tests/camera_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/camera/tests/camera_item.test.mjs
+++ b/extensions/camera/tests/camera_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/film/tests/film_collection.test.mjs
+++ b/extensions/film/tests/film_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/film/tests/film_item.test.mjs
+++ b/extensions/film/tests/film_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/historical-imagery/tests/historical-imagery_collection.test.mjs
+++ b/extensions/historical-imagery/tests/historical-imagery_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -98,7 +99,7 @@ o.spec('Historical Imagery Extension Collection', () => {
     // given
     for (const role of ['producer', 'licensor', 'processor', 'host']) {
       const example = JSON.parse(await fs.readFile(examplePath));
-      example.providers = example.providers.filter((provider) => !role in provider.roles);
+      example.providers = example.providers.filter((provider) => (!role) in provider.roles);
 
       // when
       let valid = validate(example);

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.mjs
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/linz/tests/linz_collection.test.mjs
+++ b/extensions/linz/tests/linz_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -404,7 +405,7 @@ o.spec('LINZ collection', () => {
     // given
     for (const role of ['producer', 'licensor']) {
       const example = JSON.parse(await fs.readFile(examplePath));
-      example.providers = example.providers.filter((provider) => !role in provider.roles);
+      example.providers = example.providers.filter((provider) => (!role) in provider.roles);
 
       // when
       let valid = validate(example);
@@ -423,7 +424,7 @@ o.spec('LINZ collection', () => {
     // given
     for (const role of ['manager', 'custodian']) {
       const example = JSON.parse(await fs.readFile(examplePath));
-      example['linz:providers'] = example['linz:providers'].filter((provider) => !role in provider.roles);
+      example['linz:providers'] = example['linz:providers'].filter((provider) => (!role) in provider.roles);
 
       // when
       let valid = validate(example);

--- a/extensions/linz/tests/linz_item.test.mjs
+++ b/extensions/linz/tests/linz_item.test.mjs
@@ -1,9 +1,10 @@
+import Ajv from 'ajv';
+import { promises as fs } from 'fs';
 import o from 'ospec';
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
-import Ajv from 'ajv';
+
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/quality/tests/quality_collection.test.mjs
+++ b/extensions/quality/tests/quality_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/scanning/tests/scanning_collection.test.mjs
+++ b/extensions/scanning/tests/scanning_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/scanning/tests/scanning_item.test.mjs
+++ b/extensions/scanning/tests/scanning_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/template/tests/template_collection.test.mjs
+++ b/extensions/template/tests/template_collection.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/extensions/template/tests/template_item.test.mjs
+++ b/extensions/template/tests/template_item.test.mjs
@@ -1,8 +1,9 @@
-import o from 'ospec';
 import Ajv from 'ajv';
+import { promises as fs } from 'fs';
+import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
+
 import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.15",
   "type": "module",
   "scripts": {
-    "lint": "npx eslint . --fix && npm run format",
-    "format": "npm run format:markdown && npm run format:yaml",
+    "lint": "npx eslint . && npm run format",
+    "format": "npm run format:js && npm run format:markdown && npm run format:yaml",
+    "format:js": "npx eslint --fix .",
     "format:markdown": "npx prettier **/*.md --write",
     "format:yaml": "npx prettier **/*.yaml --write",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && npm run format && git add CHANGELOG.md",

--- a/validation.mjs
+++ b/validation.mjs
@@ -1,10 +1,10 @@
 import axios from 'axios';
+import { promises as fs } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { promises as fs } from 'fs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
-import iriFormats from 'stac-node-validator/iri.js';
 import { fastFormats } from 'ajv-formats/dist/formats.js';
+import iriFormats from 'stac-node-validator/iri.js';
 
 const Schemas = new Map();
 export function loadSchema(uri) {


### PR DESCRIPTION
`eslint --fix` returns an exit code 0 even when fixing things.

To format the js files, use `npm run format` instead of previously `npm run lint`.