### PR TITLE
fix: run ospec tests

### DIFF
--- a/extensions/camera/tests/camera_collection.test.mjs
+++ b/extensions/camera/tests/camera_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/camera/tests/camera_item.test.mjs
+++ b/extensions/camera/tests/camera_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/film/tests/film_collection.test.mjs
+++ b/extensions/film/tests/film_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/film/tests/film_item.test.mjs
+++ b/extensions/film/tests/film_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/historical-imagery/tests/historical-imagery_collection.test.mjs
+++ b/extensions/historical-imagery/tests/historical-imagery_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/historical-imagery/tests/historical-imagery_item.test.mjs
+++ b/extensions/historical-imagery/tests/historical-imagery_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/linz/tests/linz_collection.test.mjs
+++ b/extensions/linz/tests/linz_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/linz/tests/linz_item.test.mjs
+++ b/extensions/linz/tests/linz_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/quality/tests/quality_collection.test.mjs
+++ b/extensions/quality/tests/quality_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/scanning/tests/scanning_collection.test.mjs
+++ b/extensions/scanning/tests/scanning_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/scanning/tests/scanning_item.test.mjs
+++ b/extensions/scanning/tests/scanning_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/template/tests/template_collection.test.mjs
+++ b/extensions/template/tests/template_collection.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/extensions/template/tests/template_item.test.mjs
+++ b/extensions/template/tests/template_item.test.mjs
@@ -4,7 +4,7 @@ import o from 'ospec';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.js';
+import { AjvOptions, DefaultTimeoutMillis } from '../../../validation.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const schemaPath = join(__dirname, '..', 'schema.json');

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format:yaml": "npx prettier **/*.yaml --write",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && npm run format && git add CHANGELOG.md",
     "version-schema": "find extensions -type f -print0 | xargs -0 sed -i \"s/_STAC_VERSION_/v$npm_package_version/\"",
-    "test": "npx ospec && ./validate.sh"
+    "test": "npx ospec extensions/*/tests/*.test.mjs && ./validate.sh"
   },
   "devDependencies": {
     "@linzjs/style": "^5.1.0",


### PR DESCRIPTION
ospec does not support auto-resolving ES modules (`*.mjs`), so we have to
specify them all manually.

Also point to renamed `validation.mjs` file.