### PR TITLE
build: Bump Node.js to latest LTS, 20.13.1 TDE-1090

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,10 @@
 name: Test
 on:
   push:
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: linz/action-typescript@dee99184c4305aea6c380a52db9b2d7abaaa3e78 # v3
+        with:
+          node-version: 20.x

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "conventional-changelog-cli": "^4.1.0",
         "ospec": "^4.1.7",
         "stac-node-validator": "^1.3.0"
+      },
+      "engines": {
+        "node": "^20.13.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "conventional-changelog-cli": "^4.1.0",
     "ospec": "^4.1.7",
     "stac-node-validator": "^1.3.0"
+  },
+  "engines": {
+    "node": "^20.13.1"
   }
 }


### PR DESCRIPTION
1. Update the engine:

   ```
   jq '.engines.node = "^20.13.1"' package.json | sponge package.json
   ```
2. Update the lock file:

   ```
   npm install
   ```
3. Update the uses of `linz/action-typescript`:

   ```
   for path in .github/workflows/*.y*ml; do
       yq --inplace '(.jobs.*.steps[] | select(.uses == "linz/action-typescript*").with.node-version) = "20.x"' "$path";
   done
   ```